### PR TITLE
Add `dim` keyword and add `--output-file` cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Usage: nyaml2nxdl [OPTIONS] INPUT_FILE
   tools.
 
 Options:
+  --output-file TEXT   The output file path to write the converted file to
   --check-consistency  Check if yaml and nxdl can be converted from one to
                        another version recursively and get the same version of
                        file. E.g. from NXexample.nxdl.xml to

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ pip install -e ".[dev]"
 * **link** Define links between nodes.
 * **units** A statement introducing NeXus-compliant NXDL units arguments, like NX_VOLTAGE
 * **dimensions** Details which dimensional arrays to expect
+* **dim** Shorthand notation for dimensions, e.g., `(n, )` for an 1D array of length `n` or `(n, m)` for an 2D array of size `n x m`.
 * **enumeration** Python list of strings which are considered as recommended entries to choose from.
 * **dim_parameters** `dim` which is a child of `dimension` and the `dim` might have several attributes `ref`,
 `incr` including `index` and `value`. So while writing `yaml` file schema definition please following structure:

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ pip install -e ".[dev]"
             Rest of the doc
             rest of the doc
         </doc>
-    </field>
-    <field name="velocity">
-      <doc>
-           A single block of doc string.
-      </doc>
-    </field>
+      </field>
+      <field name="velocity">
+        <doc>
+            A single block of doc string.
+        </doc>
+      </field>
       ```
 
 

--- a/nyaml/cli.py
+++ b/nyaml/cli.py
@@ -80,6 +80,11 @@ def split_name_and_extension(file_path):
 @click.command()
 @click.argument("input-file")
 @click.option(
+    "--output-file",
+    required=False,
+    help="The output file path to write the converted file to",
+)
+@click.option(
     "--check-consistency",
     is_flag=True,
     default=False,
@@ -106,7 +111,7 @@ def split_name_and_extension(file_path):
 possible issues in yaml files",
 )
 # def launch_tool(input_file, verbose, check_consistency):
-def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency):
+def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency, output_file):
     """
     Main function that distinguishes the input file format and launches the tools.
     """
@@ -116,7 +121,9 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency):
     else:
         raise ValueError("Need a valid input file.")
     if ext == "yaml":
-        xml_out_file = raw_name + NXDL_SUFFIX
+        xml_out_file = (
+            output_file if output_file is not None else raw_name + NXDL_SUFFIX
+        )
         generate_nxdl_or_retrieve_nxdl(input_file, xml_out_file, verbose)
 
         # For consistency running
@@ -127,7 +134,9 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency):
             Path(xml_out_file).unlink()
     elif ext == "nxdl.xml":
         # if not append:
-        yaml_out_file = raw_name + "_parsed" + ".yaml"
+        yaml_out_file = (
+            output_file if output_file is not None else raw_name + "_parsed" + ".yaml"
+        )
         converter = Nxdl2yaml([], [])
         converter.print_yml(input_file, yaml_out_file, verbose)
         # Store nxdl.xml file in output yaml file under SHA HASH

--- a/nyaml/cli.py
+++ b/nyaml/cli.py
@@ -122,20 +122,20 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency, outpu
         raise ValueError("Need a valid input file.")
     if ext == "yaml":
         xml_out_file = (
-            output_file if output_file is not None else raw_name + NXDL_SUFFIX
+            output_file if output_file is not None else f"{raw_name}{NXDL_SUFFIX}"
         )
         generate_nxdl_or_retrieve_nxdl(input_file, xml_out_file, verbose)
 
         # For consistency running
         if check_consistency:
-            yaml_out_file = raw_name + "_consistency." + ext
+            yaml_out_file = f"{raw_name}_consistency.{ext}"
             converter = Nxdl2yaml([], [])
             converter.print_yml(xml_out_file, yaml_out_file, verbose)
             Path(xml_out_file).unlink()
     elif ext == "nxdl.xml":
         # if not append:
         yaml_out_file = (
-            output_file if output_file is not None else raw_name + "_parsed" + ".yaml"
+            output_file if output_file is not None else f"{raw_name}_parsed.yaml"
         )
         converter = Nxdl2yaml([], [])
         converter.print_yml(input_file, yaml_out_file, verbose)
@@ -158,7 +158,7 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency, outpu
 
         # Taking care of consistency running
         if check_consistency:
-            xml_out_file = raw_name + "_consistency." + ext
+            xml_out_file = f"{raw_name}_consistency.{ext}"
             generate_nxdl_or_retrieve_nxdl(yaml_out_file, xml_out_file, verbose)
             Path.unlink(yaml_out_file)
     else:

--- a/nyaml/cli.py
+++ b/nyaml/cli.py
@@ -122,7 +122,7 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency, outpu
         raise ValueError("Need a valid input file.")
     if ext == "yaml":
         xml_out_file = (
-            output_file if output_file is not None else f"{raw_name}{NXDL_SUFFIX}"
+            f"{raw_name}{NXDL_SUFFIX}" if output_file is None else output_file
         )
         generate_nxdl_or_retrieve_nxdl(input_file, xml_out_file, verbose)
 
@@ -135,7 +135,9 @@ def launch_tool(input_file, verbose, do_not_store_nxdl, check_consistency, outpu
     elif ext == "nxdl.xml":
         # if not append:
         yaml_out_file = (
-            output_file if output_file is not None else f"{raw_name}_parsed.yaml"
+            f"{raw_name}_parsed.yaml"
+            if output_file is None
+            else f"{raw_name}_parsed.yaml"
         )
         converter = Nxdl2yaml([], [])
         converter.print_yml(input_file, yaml_out_file, verbose)

--- a/nyaml/helper.py
+++ b/nyaml/helper.py
@@ -80,7 +80,7 @@ NXDL_LINK_ATTRIBUTES = ("name", "target", "napimount")
 # Set up attributes for yaml version
 YAML_GROUP_ATTRIBUTES = (*NXDL_GROUP_ATTRIBUTES, "exists")
 
-YAML_FIELD_ATTRIBUTES = (*NXDL_FIELD_ATTRIBUTES[0:-1], "unit", "exists")
+YAML_FIELD_ATTRIBUTES = (*NXDL_FIELD_ATTRIBUTES[0:-1], "unit", "exists", "dim")
 
 YAML_ATTRIBUTES_ATTRIBUTES = (
     *NXDL_ATTRIBUTES_ATTRIBUTES,

--- a/nyaml/nyaml2nxdl.py
+++ b/nyaml/nyaml2nxdl.py
@@ -933,6 +933,8 @@ def xml_handle_fields_or_group(
             elif ele_type == "field" and attr == "unit":
                 xml_handle_units(elemt_obj, vval)
                 xml_handle_comment(obj, line_number, line_loc, elemt_obj)
+            elif ele_type == "field" and attr == "dim":
+                xml_handle_dim(dct, obj, keyword, value)
             elif attr in allowed_attr and not isinstance(vval, dict) and vval:
                 validate_field_attribute_and_value(attr, vval, allowed_attr, value)
                 elemt_obj.set(attr, check_for_mapping_char_other(vval))

--- a/nyaml/nyaml2nxdl.py
+++ b/nyaml/nyaml2nxdl.py
@@ -458,6 +458,33 @@ def xml_handle_dimensions(dct, obj, keyword, value: dict):
         recursive_build(dims, value, verbose=None)
 
 
+def xml_handle_dim(dct, obj, keyword, value):
+    """
+    This function creates a 'dimensions' element instance, and appends it to an existing element.
+    Allows for handling numpy tensor notation of dimensions. That is,
+    dimensions:
+      rank: 1
+      dim: (1, 3)
+    can be replaced by
+    dim: (3,)
+    """
+    if isinstance(value, str):
+        if value[0] == "(" and value[-1] == ")":
+            valid_dims = []
+            for entry in value[1:-1].replace(" ", "").split(","):
+                if len(entry) > 0:  # ignore trailing comma and empty mnemonics
+                    valid_dims.append(entry)
+            if len(valid_dims) > 0:
+                dims = ET.SubElement(obj, "dimensions")
+                dims.set("rank", str(len(valid_dims)))
+                dim_idx = 1
+                for dim_name in valid_dims:
+                    dim = ET.SubElement(dims, "dim")
+                    dim.set("index", str(dim_idx))
+                    dim.set("value", str(dim_name))
+                    dim_idx += 1
+
+
 # pylint: disable=too-many-locals, too-many-arguments, too-many-statements
 def xml_handle_dim_from_dimension_dict(
     dct, dims_obj, keyword, value, rank, verbose=False
@@ -1016,6 +1043,8 @@ def recursive_build(obj, dct, verbose):
             xml_handle_enumeration(dct, obj, keyword, value, verbose)
         elif keyword == "dimensions":
             xml_handle_dimensions(dct, obj, keyword, value)
+        elif keyword == "dim":
+            xml_handle_dim(dct, obj, keyword, value)
         elif keyword == "exists":
             xml_handle_exists(dct, obj, keyword, value)
         # Handles fileds e.g. AXISNAME

--- a/nyaml/nyaml2nxdl.py
+++ b/nyaml/nyaml2nxdl.py
@@ -458,7 +458,7 @@ def xml_handle_dimensions(dct, obj, keyword, value: dict):
         recursive_build(dims, value, verbose=None)
 
 
-def xml_handle_dim(dct, obj, keyword, value):
+def xml_handle_dim(obj, value):
     """
     This function creates a 'dimensions' element instance, and appends it to an existing element.
     Allows for handling numpy tensor notation of dimensions. That is,
@@ -934,7 +934,7 @@ def xml_handle_fields_or_group(
                 xml_handle_units(elemt_obj, vval)
                 xml_handle_comment(obj, line_number, line_loc, elemt_obj)
             elif ele_type == "field" and attr == "dim":
-                xml_handle_dim(dct, obj, keyword, value)
+                xml_handle_dim(obj, value)
             elif attr in allowed_attr and not isinstance(vval, dict) and vval:
                 validate_field_attribute_and_value(attr, vval, allowed_attr, value)
                 elemt_obj.set(attr, check_for_mapping_char_other(vval))
@@ -1046,7 +1046,7 @@ def recursive_build(obj, dct, verbose):
         elif keyword == "dimensions":
             xml_handle_dimensions(dct, obj, keyword, value)
         elif keyword == "dim":
-            xml_handle_dim(dct, obj, keyword, value)
+            xml_handle_dim(obj, value)
         elif keyword == "exists":
             xml_handle_exists(dct, obj, keyword, value)
         # Handles fileds e.g. AXISNAME

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -1,0 +1,14 @@
+category: application
+doc: |
+  This is a test for the dimension keywords.
+type: group
+NXarchive(NXobject):
+  (NXentry):
+    my_dim_array(NX_NUMBER):
+      doc: Test
+      dim: (2,)
+    my_dim_array2(NX_NUMBER):
+      doc: Testarray with dimensions spelled out
+      dimensions:
+        rank: 1
+        dim: [[1, 2]]

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-#
+# 
 # Copyright (C) 2014-2023 NeXus International Advisory Committee (NIAC)
-#
+# 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2023 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         This is a test for the dimension keywords.
+    </doc>
+    <group type="NXentry">
+        <field name="my_dim_array" type="NX_NUMBER">
+            <doc>
+                 Test
+            </doc>
+            <dimensions rank="1">
+                <dim index="1" value="2"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_array2" type="NX_NUMBER">
+            <doc>
+                 Testarray with dimensions spelled out
+            </doc>
+            <dimensions rank="1">
+                <dim index="1" value="2"/>
+            </dimensions>
+        </field>
+    </group>
+</definition>

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -481,6 +481,25 @@ def test_nxdl2yaml_doc():
     Path.unlink(parsed_yaml_file)
 
 
+def test_nyaml_dim_keyword(tmp_path):
+    """
+    The dim keyword is correctly translated into nxdl with rank and dim.
+    """
+
+    pwd = Path(__file__).parent
+    input_file = pwd / "data/dim_keyword.yaml"
+    ref_file = pwd / "data/ref_dim_keyword.nxdl.xml"
+    parsed_file = tmp_path / "dim_keyword.nxdl.xml"
+
+    result = CliRunner().invoke(
+        nyaml2nxdl.launch_tool,
+        ["--do-not-store-nxdl", str(input_file), "--output-file", str(parsed_file)],
+    )
+
+    assert result.exit_code == 0, "Error in converter execution."
+    assert ref_file.read_text() == parsed_file.read_text()
+
+
 @pytest.mark.parametrize(
     "test_input,output,is_valid",
     [


### PR DESCRIPTION
### Dim keyword

Creates a 'dimensions' element instance, and appends it to an existing element.
Allows for handling numpy tensor notation of dimensions. That is,
```yaml
    dimensions:
      rank: 1
      dim: (1, 3)
```
can be replaced by

```yaml
    dim: (3,)
```
### Output file

A new cli option has been added to specify the output file:

```bash
nyaml2nxdl my_file.yaml --output-file my_file.nxdl.xml
```

No checks are done for the output file name (i.e., it is not checked for matching `yaml` and `nxdl.xml` combination)