### PR TITLE
Simplify xref handling

### DIFF
--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -373,9 +373,9 @@ class Nxdl2yaml:
             url = matches.group(3)
             indent = indent + DEPTH_SIZE  # see example in func doc
             return (
-                f'{indent}"{xref_key}:\n{indent + DEPTH_SIZE}{spec_key}: {spec}'
+                f"{indent}{xref_key}:\n{indent + DEPTH_SIZE}{spec_key}: {spec}"
                 f"\n{indent + DEPTH_SIZE}{term_key}"
-                f': {term}\n{indent + DEPTH_SIZE}{url_key}: {url}"'
+                f": {term}\n{indent + DEPTH_SIZE}{url_key}: {url}"
             ), True
         return text, False
 

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -430,7 +430,7 @@ class Nxdl2yaml:
                 ):  # if not starts with 'spaces and/or \n'
                     mod_doc = "\n" + mod_doc
                 # doc_str = f"{doc_str}{indent} - |\n{textwrap.indent(mod_doc, indent+'  ')}\n"
-                doc_str = f"{doc_str}{indent} - |{textwrap.indent(mod_doc, '')}\n"
+                doc_str = f"{doc_str}{indent}- |{textwrap.indent(mod_doc, '')}\n"
         else:
             doc_str = f"{indent}{tag}: |{text}\n"
 

--- a/tests/data/doc_yaml2nxdl.yaml
+++ b/tests/data/doc_yaml2nxdl.yaml
@@ -22,9 +22,9 @@ NXarchive(NXobject):
     experiment_identifier(NX_CHAR):
       doc: 
        - |
-        "unique identifier for the experimenta
+        unique identifier for the experimenta
           lkokö
-          sddfdfd"
+          sddfdfd
        - |
         xref:
           spec: ISO 18115-1:2023

--- a/tests/data/doc_yaml2nxdl.yaml
+++ b/tests/data/doc_yaml2nxdl.yaml
@@ -22,9 +22,9 @@ NXarchive(NXobject):
     experiment_identifier(NX_CHAR):
       doc: 
        - |
-        unique identifier for the experimenta
+        "unique identifier for the experimenta
           lkokö
-          sddfdfd
+          sddfdfd"
        - |
         xref:
           spec: ISO 18115-1:2023

--- a/tests/data/ref_doc_nxdl2yaml.yaml
+++ b/tests/data/ref_doc_nxdl2yaml.yaml
@@ -15,37 +15,37 @@ NXarchive(NXobject):
     title:
     experiment_identifier(NX_CHAR):
       doc:
-       - |
+      - |
         unique identifier for the experimenta
           lkokö
           sddfdfd
-       - |
+      - |
         xref:
           spec: ISO 18115-1:2023
           term: 12.58
           url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58
-       - |
+      - |
         This is test doc.
     experiment_description(NX_CHAR):
       doc:
-       - |
+      - |
         Part1: Text line 1.
         part1: Text line 2
-       - |
+      - |
         xref:
           spec: spec
           term: term
           url: url
     double_iso_string(NX_CHAR):
       doc:
-       - |
+      - |
         Way of scanning the energy axis (fixed or sweep).
-       - |
+      - |
         xref:
           spec: ISO 18115-1:2023
           term: 12.65
           url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.65
-       - |
+      - |
         xref:
           spec: ISO 18115-1:2023
           term: 12.66
@@ -58,3 +58,93 @@ NXarchive(NXobject):
       doc: |
         unique identifier for this measurement as provided by the facility
     start_time(NX_DATE_TIME):
+
+# ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
+# 9cfceb233f3ce5a3907d27287980419724a523711418d44196907c44c181f743
+# <?xml version='1.0' encoding='UTF-8'?>
+# <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+# <!--
+# # NeXus - Neutron and X-ray Common Data Format
+# #
+# # Copyright (C) 2014-2023 NeXus International Advisory Committee (NIAC)
+# #
+# # This library is free software; you can redistribute it and/or
+# # modify it under the terms of the GNU Lesser General Public
+# # License as published by the Free Software Foundation; either
+# # version 3 of the License, or (at your option) any later version.
+# #
+# # This library is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # Lesser General Public License for more details.
+# #
+# # You should have received a copy of the GNU Lesser General Public
+# # License along with this library; if not, write to the Free Software
+# # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# #
+# # For further information, see http://www.nexusformat.org
+# -->
+# <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+#   <doc>
+#        This is a definition for data to be archived by ICAT (http://www.icatproject.org/).
+# 
+#        .. text from the icatproject.org site
+# 
+#        		the database (with supporting software) that provides an
+#        		interface to all ISIS experimental data and will provide
+#        		a mechanism to link all aspects of ISIS research from
+#        		proposal through to publication.
+#   </doc>
+#   <group type="NXentry" name="entry">
+#     <attribute name="index"/>
+#     <field name="title"/>
+#     <field name="experiment_identifier" type="NX_CHAR">
+#       <doc>
+#            unique identifier for the experimenta
+#              lkokö
+#              sddfdfd
+# 
+#              This concept is related to term `12.58`_ of the ISO 18115-1:2023 standard.
+# 
+#              .. _12.58: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58
+# 
+#            This is test doc.
+#       </doc>
+#     </field>
+#     <field name="experiment_description" type="NX_CHAR">
+#       <doc>
+#            Part1: Text line 1.
+#            part1: Text line 2
+# 
+#            This concept is related to term `term`_ of the spec standard.
+# 
+#            .. _term: url
+#       </doc>
+#     </field>
+#     <field name="double_iso_string" type="NX_CHAR">
+#       <doc>
+#          Way of scanning the energy axis (fixed or sweep).
+# 
+#          This concept is related to term `12.65`_ of the ISO 18115-1:2023 standard.
+# 
+#          .. _12.65: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.65
+# 
+#          This concept is related to term `12.66`_ of the ISO 18115-1:2023 standard.
+# 
+#          .. _12.66: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.66
+#       </doc>
+#     </field>
+#     <field name="collection_identifier" type="NX_CHAR">
+#       <doc>
+#            ID of user or DAQ define group of data files
+#            Brief summary of the collection, including grouping criteria
+#       </doc>
+#     </field>
+#     <field name="entry_identifier" type="NX_CHAR">
+#       <doc>
+#            unique identifier for this measurement as provided by the facility
+#       </doc>
+#     </field>
+#     <field name="start_time" type="NX_DATE_TIME"/>
+#   </group>
+# </definition>

--- a/tests/data/ref_doc_nxdl2yaml.yaml
+++ b/tests/data/ref_doc_nxdl2yaml.yaml
@@ -20,10 +20,10 @@ NXarchive(NXobject):
           lkokö
           sddfdfd
        - |
-        "xref:
+        xref:
           spec: ISO 18115-1:2023
           term: 12.58
-          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58"
+          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58
        - |
         This is test doc.
     experiment_description(NX_CHAR):
@@ -32,24 +32,24 @@ NXarchive(NXobject):
         Part1: Text line 1.
         part1: Text line 2
        - |
-        "xref:
+        xref:
           spec: spec
           term: term
-          url: url"
+          url: url
     double_iso_string(NX_CHAR):
       doc:
        - |
         Way of scanning the energy axis (fixed or sweep).
        - |
-        "xref:
+        xref:
           spec: ISO 18115-1:2023
           term: 12.65
-          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.65"
+          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.65
        - |
-        "xref:
+        xref:
           spec: ISO 18115-1:2023
           term: 12.66
-          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.66"
+          url: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.66
     collection_identifier(NX_CHAR):
       doc: |
         ID of user or DAQ define group of data files


### PR DESCRIPTION
Fixes #13.

- [x] Remove "" strings in xref
- [x] Use consistent two-space for individual elements in multiline docs.