### PR TITLE
Updates vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": true
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },


### PR DESCRIPTION
Since vscode 1.85 the on save actions for vscode expect an enum value instead of a boolean value, see https://code.visualstudio.com/updates/v1_85#_editor

This adapts to this