### PR TITLE
Fixes tabs in docstring

### DIFF
--- a/nyaml/nyaml2nxdl.py
+++ b/nyaml/nyaml2nxdl.py
@@ -231,7 +231,7 @@ def format_nxdl_doc(string):
         formatted_doc = "\n" + "\n".join(text_lines)
     if not formatted_doc.endswith("\n"):
         formatted_doc += "\n"
-    return formatted_doc
+    return formatted_doc.expandtabs(4)
 
 
 def check_for_mapping_char_other(text):

--- a/tests/data/no_tabs_yaml2nxdl.yaml
+++ b/tests/data/no_tabs_yaml2nxdl.yaml
@@ -1,0 +1,42 @@
+category: base
+doc: |
+  * Each :ref:`NXdata` group will define one field as the default
+    plottable data.  The value of the ``signal`` attribute names this field.
+    Additional fields may be used to describe the dimension scales and
+    uncertainities.
+    The ``auxiliary_signals`` attribute is a list of the other fields
+    to be plotted with the ``signal`` data.
+  * The plottable data may be of arbitrary rank up to a maximum
+    of ``NX_MAXRANK=32`` (for compatibility with backend file formats).
+  * The plottable data will be named as the value of
+    the group ``signal`` attribute, such as::
+
+      data:NXdata
+        @signal = "counts"
+        @axes = "mr"
+        @mr_indices = 0
+        counts: float[100]  --> the default dependent data
+        mr: float[100]  --> the default independent data
+
+    The field named in the ``signal`` attribute **must** exist, either
+    directly as a NeXus field or defined through a link.
+symbols:
+  doc: |
+    These symbols will be used below to coordinate fields with the same shape.
+  dataRank: |
+    rank of the ``DATA`` field
+  n: |
+    length of the ``AXISNAME`` field
+  nx: |
+    length of the ``x`` field
+  ny: |
+    length of the ``y`` field
+  nz: |
+    length of the ``z`` field
+type: group
+ignoreExtraFields: true
+ignoreExtraAttributes: true
+NXtest(NXobject):
+  title:
+    doc: |
+      Title for the plot.

--- a/tests/data/ref_doc_yaml2nxdl.nxdl.xml
+++ b/tests/data/ref_doc_yaml2nxdl.nxdl.xml
@@ -27,10 +27,10 @@
          
          .. text from the icatproject.org site
          
-         		the database (with supporting software) that provides an
-         		interface to all ISIS experimental data and will provide
-         		a mechanism to link all aspects of ISIS research from
-         		proposal through to publication.
+                 the database (with supporting software) that provides an
+                 interface to all ISIS experimental data and will provide
+                 a mechanism to link all aspects of ISIS research from
+                 proposal through to publication.
          
          This concept is related to term `1.1`_ of the ISO 18115-1:2023 standard.
          

--- a/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
+++ b/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" ignoreExtraFields="true" ignoreExtraAttributes="true" name="NXtest" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <doc>
+             These symbols will be used below to coordinate fields with the same
+             shape.
+        </doc>
+        <symbol name="dataRank">
+            <doc>
+                 rank of the ``DATA`` field
+            </doc>
+        </symbol>
+        <symbol name="n">
+            <doc>
+                 length of the ``AXISNAME`` field
+            </doc>
+        </symbol>
+        <symbol name="nx">
+            <doc>
+                 length of the ``x`` field
+            </doc>
+        </symbol>
+        <symbol name="ny">
+            <doc>
+                 length of the ``y`` field
+            </doc>
+        </symbol>
+        <symbol name="nz">
+            <doc>
+                 length of the ``z`` field
+            </doc>
+        </symbol>
+    </symbols>
+    <doc>
+         * Each :ref:`NXdata` group will define one field as the default
+           plottable data.  The value of the ``signal`` attribute names this field.
+           Additional fields may be used to describe the dimension scales and
+           uncertainities.
+           The ``auxiliary_signals`` attribute is a list of the other fields
+           to be plotted with the ``signal`` data.
+         * The plottable data may be of arbitrary rank up to a maximum
+           of ``NX_MAXRANK=32`` (for compatibility with backend file formats).
+         * The plottable data will be named as the value of
+           the group ``signal`` attribute, such as::
+
+            data:NXdata
+              @signal = "counts"
+              @axes = "mr"
+              @mr_indices = 0
+              counts: float[100]  --&gt; the default dependent data
+              mr: float[100]  --&gt; the default independent data
+
+           The field named in the ``signal`` attribute **must** exist, either
+           directly as a NeXus field or defined through a link.
+    </doc>
+    <field name="title">
+        <doc>
+             Title for the plot.
+        </doc>
+    </field>
+</definition>

--- a/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
+++ b/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
@@ -64,14 +64,14 @@
            of ``NX_MAXRANK=32`` (for compatibility with backend file formats).
          * The plottable data will be named as the value of
            the group ``signal`` attribute, such as::
-
-            data:NXdata
-              @signal = "counts"
-              @axes = "mr"
-              @mr_indices = 0
-              counts: float[100]  --&gt; the default dependent data
-              mr: float[100]  --&gt; the default independent data
-
+         
+             data:NXdata
+               @signal = "counts"
+               @axes = "mr"
+               @mr_indices = 0
+               counts: float[100]  --&gt; the default dependent data
+               mr: float[100]  --&gt; the default independent data
+         
            The field named in the ``signal`` attribute **must** exist, either
            directly as a NeXus field or defined through a link.
     </doc>

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -494,6 +494,39 @@ def test_nyaml_dim_keyword(tmp_path):
     assert ref_file.read_text() == parsed_file.read_text()
 
 
+def test_yaml2nxdl_no_tabs(tmp_path):
+    """
+    Test the proper conversion of yaml2nxdl without producing tabs.
+    """
+    pwd = Path(__file__).parent
+
+    doc_file = pwd / "data/no_tabs_yaml2nxdl.yaml"
+    ref_doc_file = pwd / "data/ref_no_tabs_yaml2nxdl.nxdl.xml"
+    out_doc_file = tmp_path / "no_tabs_yaml2nxdl.nxdl.xml"
+    result = CliRunner().invoke(
+        nyaml2nxdl.launch_tool, [str(doc_file), "--output-file", str(out_doc_file)]
+    )
+    assert result.exit_code == 0, f"Error: Having issue running input file {doc_file}."
+
+    ref_nxdl = ET.parse(str(ref_doc_file)).getroot()
+    out_nxdl = ET.parse(str(out_doc_file)).getroot()
+
+    def compare_nxdl_doc(parent1, parent2):
+        if len(parent1) > 0 and len(parent2) > 0:
+            for par1, par2 in zip(parent1, parent2):
+                compare_nxdl_doc(par1, par2)
+
+        elif (
+            remove_namespace_from_tag(parent1.tag) == "doc"
+            and remove_namespace_from_tag(parent2.tag) == "doc"
+        ):
+            assert (
+                parent1.text == parent2.text
+            ), f"DOCS ARE NOT SAME: node {parent1}, node {parent2}"
+
+    compare_nxdl_doc(ref_nxdl, out_nxdl)
+
+
 @pytest.mark.parametrize(
     "test_input,output,is_valid",
     [


### PR DESCRIPTION
For some docstrings tabs are produced instead of spaces which produces a warning in rst parsing.
This fixes it.