### PR TITLE
nyaml supports both dimensions and dim

### DIFF
--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -667,7 +667,9 @@ class Nxdl2yaml:
         possible_dimemsion_attrs = ["rank"]
 
         def handle_dim_with_value_and_index(depth, node, file_out, dimension_doc):
-            """Handle the dim if it has only value and index attributes"""
+            """
+            Handle <dimenstions> element if <dim> has only value and index attributes, and
+            <diemensions> element has only one attribute 'rank', but has no doc."""
             indent = depth * DEPTH_SIZE
             dim_index_value = ""
             dim_cmnt_nodes = []
@@ -787,8 +789,8 @@ class Nxdl2yaml:
                 else:
                     raise ValueError(
                         f"Dimension has an attribute {attr} that is not valid."
-                        f"Current the allowd atributes are {possible_dimemsion_attrs}."
-                        f" Please have a look"
+                        f"Currently allowed attributes are {possible_dimemsion_attrs}."
+                        f"Please have a look"
                     )
             # taking care of dimension doc
             dimension_doc = ""

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -666,92 +666,144 @@ class Nxdl2yaml:
         possible_dim_attrs = ["ref", "required", "incr", "refindex"]
         possible_dimemsion_attrs = ["rank"]
 
-        # taking care of Dimension tag
-        indent = depth * DEPTH_SIZE
-        tag = remove_namespace_from_tag(node.tag)
-        file_out.write(f"{indent}{tag}:\n")
-        for attr, value in node.attrib.items():
-            if attr in possible_dimemsion_attrs and not isinstance(value, dict):
-                indent = (depth + 1) * DEPTH_SIZE
-                file_out.write(f"{indent}{attr}: {value}\n")
+        def handle_dim_with_value_and_index(depth, node, file_out, dimension_doc):
+            """Handle the dim if it has only value and index attributes"""
+            indent = depth * DEPTH_SIZE
+            dim_index_value = ""
+            dim_cmnt_nodes = []
+            for child in list(node):
+                tag = remove_namespace_from_tag(child.tag)
+                child_attrs = child.attrib
+                # taking care of index and value attributes
+                if tag == "dim":
+                    # If dim has only one attr 'value' use numpy style
+                    if child_attrs.get("value", "") and not dimension_doc:
+                        dim_index_value = (
+                            f"{dim_index_value[:-1]} {child_attrs['value']},)"
+                            if dim_index_value
+                            else f"({child_attrs['value']},)"
+                        )
+                        node.remove(child)
+                elif tag == CMNT_TAG and self.include_comment:
+                    # Store and remove node so that comment nodes from dim node so
+                    # that it does not call in xmlparser function
+                    dim_cmnt_nodes.append(child)
+                    node.remove(child)
+            # All 'dim' element comments on top of 'dim' yaml key
+            if dim_cmnt_nodes:
+                for ch_nd in dim_cmnt_nodes:
+                    self.handle_comment(depth, ch_nd, file_out)
+
+            if dim_index_value:
+                value = (
+                    dim_index_value[:-2] + ")"
+                    if len(dim_index_value.split(",")) > 2
+                    else dim_index_value
+                )
+                file_out.write(f"{indent}dim: {value}\n")
             else:
                 raise ValueError(
-                    f"Dimension has an attribute {attr} that is not valid."
-                    f"Current the allowd atributes are {possible_dimemsion_attrs}."
-                    f" Please have a look"
+                    "Dimension has no 'value' and 'index' attributes. "
+                    "One of them is required."
                 )
-        # taking care of dimension doc
-        for child in list(node):
-            tag = remove_namespace_from_tag(child.tag)
-            if tag == "doc":
-                text = self.handle_not_root_level_doc(depth + 1, child.text)
-                file_out.write(text)
-                node.remove(child)
 
-        dim_index_value = ""
-        dim_other_parts = {}
-        dim_cmnt_node = []
-        # taking care of dim and doc children of dimension
-        for child in list(node):
-            tag = remove_namespace_from_tag(child.tag)
-            child_attrs = child.attrib
-            # taking care of index and value attributes
-            if tag == "dim":
-                # taking care of index and value in format [[index, value]]
-                index = child_attrs.pop("index", "")
-                value = child_attrs.pop("value", "")
-                dim_index_value = f"{dim_index_value}[{index}, {value}], "
+        def handle_dim_with_all_dim_attr(depth, node, file_out, possible_dim_attrs):
+            """Handle the dim if it has other attributes along with value and index"""
+            dim_index_value = ""
+            dim_other_parts = {}
+            dim_cmnt_nodes = []
+            # Taking care of dim and doc children of dimension
+            for child in list(node):
+                tag = remove_namespace_from_tag(child.tag)
+                child_attrs = child.attrib
+                # taking care of index and value attributes
+                if tag == "dim":
+                    # taking care of index and value in format [[index, value]]
+                    index = child_attrs.pop("index", "")
+                    value = child_attrs.pop("value", "")
+                    dim_index_value = f"{dim_index_value}[{index}, {value}], "
 
-                # Taking care of doc comes as child of dim
-                for cchild in list(child):
-                    ttag = cchild.tag.split("}", 1)[1]
-                    if ttag == ("doc"):
-                        if ttag not in dim_other_parts:
-                            dim_other_parts[ttag] = []
-                        text = cchild.text
-                        dim_other_parts[ttag].append(text.strip())
-                        child.remove(cchild)
-                        continue
-                # taking care of other attributes except index and value
-                for attr, value in child_attrs.items():
-                    if attr in possible_dim_attrs:
-                        if attr not in dim_other_parts:
-                            dim_other_parts[attr] = []
-                        dim_other_parts[attr].append(value)
-            if tag == CMNT_TAG and self.include_comment:
-                # Store and remove node so that comment nodes from dim node so
-                # that it does not call in xmlparser function
-                dim_cmnt_node.append(child)
-                node.remove(child)
+                    # Taking care of doc comes as child of dim
+                    for cchild in list(child):
+                        ttag = cchild.tag.split("}", 1)[1]
+                        if ttag == ("doc"):
+                            if ttag not in dim_other_parts:
+                                dim_other_parts[ttag] = []
+                            text = cchild.text
+                            dim_other_parts[ttag].append(text.strip())
+                            child.remove(cchild)
+                            continue
+                    # taking care of other attributes except index and value
+                    for attr, value in child_attrs.items():
+                        if attr in possible_dim_attrs:
+                            if attr not in dim_other_parts:
+                                dim_other_parts[attr] = []
+                            dim_other_parts[attr].append(value)
+                if tag == CMNT_TAG and self.include_comment:
+                    # Store and remove node so that comment nodes from dim node so
+                    # that it does not call in xmlparser function
+                    dim_cmnt_nodes.append(child)
+                    node.remove(child)
 
-        # All 'dim' element comments on top of 'dim' yaml key
-        if dim_cmnt_node:
-            for ch_nd in dim_cmnt_node:
-                self.handle_comment(depth + 1, ch_nd, file_out)
-        # index and value attributes of dim elements
-        indent = (depth + 1) * DEPTH_SIZE
-        value = dim_index_value[:-2] or ""
-        file_out.write(f"{indent}dim: [{value}]\n")
-
-        # Write the attributes, except index and value, and doc of dim as child of dim_parameter.
-        # But the doc or attributes for each dim come inside list according to the order of dim.
-        if dim_other_parts:
+            # All 'dim' element comments on top of 'dim' yaml key
+            if dim_cmnt_nodes:
+                for ch_nd in dim_cmnt_nodes:
+                    self.handle_comment(depth + 1, ch_nd, file_out)
+            # index and value attributes of dim elements
             indent = (depth + 1) * DEPTH_SIZE
-            file_out.write(f"{indent}dim_parameters:\n")
-            # depth = depth + 2 dim_parameter has child such as doc of dim
-            indent = (depth + 2) * DEPTH_SIZE
-            for key, value in dim_other_parts.items():
-                if key == "doc":
-                    value = self.handle_not_root_level_doc(
-                        depth + 2, str(value), key, file_out
-                    )
+            # Numpy style for dim
+            value = dim_index_value[:-2] or ""
+            file_out.write(f"{indent}dim: [{value}]\n")
+
+            # Write the attributes, except index and value, and doc of dim as child of dim_parameter.
+            # But the doc or attributes for each dim come inside list according to the order of dim.
+            if dim_other_parts:
+                indent = (depth + 1) * DEPTH_SIZE
+                file_out.write(f"{indent}dim_parameters:\n")
+                # depth = depth + 2 dim_parameter has child such as doc of dim
+                indent = (depth + 2) * DEPTH_SIZE
+                for key, value in dim_other_parts.items():
+                    if key == "doc":
+                        value = self.handle_not_root_level_doc(
+                            depth + 2, str(value), key, file_out
+                        )
+                    else:
+                        # Increase depth size inside handle_map...() for writing text with one
+                        # more indentation.
+                        file_out.write(
+                            f"{indent}{key}: "
+                            f"{handle_mapping_char(value, depth + 3, False)}\n"
+                        )
+
+        # Dimension has other attributes including index and value
+        if remove_namespace_from_tag(node[0].tag) == "doc" or len(node.attrib) > 0:
+            indent = depth * DEPTH_SIZE
+            tag = remove_namespace_from_tag(node.tag)
+            file_out.write(f"{indent}{tag}:\n")
+            for attr, value in node.attrib.items():
+                if attr in possible_dimemsion_attrs and not isinstance(value, dict):
+                    indent = (depth + 1) * DEPTH_SIZE
+                    file_out.write(f"{indent}{attr}: {value}\n")
                 else:
-                    # Increase depth size inside handle_map...() for writing text with one
-                    # more indentation.
-                    file_out.write(
-                        f"{indent}{key}: "
-                        f"{handle_mapping_char(value, depth + 3, False)}\n"
+                    raise ValueError(
+                        f"Dimension has an attribute {attr} that is not valid."
+                        f"Current the allowd atributes are {possible_dimemsion_attrs}."
+                        f" Please have a look"
                     )
+            # taking care of dimension doc
+            dimension_doc = ""
+            for child in list(node):
+                tag = remove_namespace_from_tag(child.tag)
+                if tag == "doc":
+                    dimension_doc = self.handle_not_root_level_doc(
+                        depth + 1, child.text
+                    )
+                    file_out.write(dimension_doc)
+                    node.remove(child)
+            handle_dim_with_all_dim_attr(depth, node, file_out, possible_dim_attrs)
+        # Dimension has only index and value
+        else:
+            handle_dim_with_value_and_index(depth, node, file_out, dimension_doc="")
 
     def handle_enumeration(self, depth, node, file_out):
         """

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -664,12 +664,12 @@ class Nxdl2yaml:
           and attributes of dim has been handled inside this function here.
         """
         possible_dim_attrs = ["ref", "required", "incr", "refindex"]
-        possible_dimemsion_attrs = ["rank"]
+        possible_dimension_attrs = ["rank"]
 
         def handle_dim_with_value_and_index(depth, node, file_out, dimension_doc):
             """
-            Handle <dimenstions> element if <dim> has only value and index attributes, and
-            <diemensions> element has only one attribute 'rank', but has no doc."""
+            Handle <dimensions> element if <dim> has only value and index attributes, and
+            <diemensions> element has only one attribute 'rank', but no doc."""
             indent = depth * DEPTH_SIZE
             dim_index_value = ""
             dim_cmnt_nodes = []
@@ -704,26 +704,21 @@ class Nxdl2yaml:
                 )
                 file_out.write(f"{indent}dim: {value}\n")
             else:
-                raise ValueError(
-                    "Dimension has no 'value' and 'index' attributes. "
-                    "One of them is required."
-                )
+                raise ValueError("The dim element must have at least a 'value'.")
 
         def handle_dim_with_all_dim_attr(depth, node, file_out, possible_dim_attrs):
-            """Handle the dim if it has other attributes along with value and index"""
+            """Handle the dim if it has other attributes along with 'value' and 'index'"""
             dim_index_value = []
             dim_other_parts = {}
             dim_cmnt_nodes = []
-            # Taking care of dim and doc children of dimension
+            # Taking care of dim and doc children of dimensions
             for child in list(node):
                 tag = remove_namespace_from_tag(child.tag)
                 child_attrs = child.attrib
                 # taking care of index and value attributes
                 if tag == "dim":
                     # taking care of index and value in format [[index, value]]
-                    # index = child_attrs.pop("index", "")
                     value = child_attrs.pop("value", "")
-                    # dim_index_value = f"{dim_index_value}[{index}, {value}], "
                     dim_index_value.append(value)
                     # Taking care of doc comes as child of dim
                     for cchild in list(child):
@@ -735,7 +730,7 @@ class Nxdl2yaml:
                             dim_other_parts[ttag].append(text.strip())
                             child.remove(cchild)
                             continue
-                    # taking care of other attributes except index and value
+                    # Taking care of other attributes except index and value
                     for attr, value in child_attrs.items():
                         if attr in possible_dim_attrs:
                             if attr not in dim_other_parts:
@@ -761,7 +756,7 @@ class Nxdl2yaml:
             )
             file_out.write(f"{indent}dim: ({value})\n")
 
-            # Write the attributes, except index and value, and doc of dim as child of dim_parameter.
+            # Write the attributes, except index and value, and doc of dim as child of dim_parameters.
             # But the doc or attributes for each dim come inside list according to the order of dim.
             if dim_other_parts:
                 indent = (depth + 1) * DEPTH_SIZE
@@ -787,16 +782,16 @@ class Nxdl2yaml:
             tag = remove_namespace_from_tag(node.tag)
             file_out.write(f"{indent}{tag}:\n")
             for attr, value in node.attrib.items():
-                if attr in possible_dimemsion_attrs and not isinstance(value, dict):
+                if attr in possible_dimension_attrs and not isinstance(value, dict):
                     indent = (depth + 1) * DEPTH_SIZE
                     file_out.write(f"{indent}{attr}: {value}\n")
                 else:
                     raise ValueError(
                         f"Dimension has an attribute {attr} that is not valid."
-                        f"Currently allowed attributes are {possible_dimemsion_attrs}."
-                        f"Please have a look"
+                        f"Currently allowed attributes are {possible_dimension_attrs}."
+                        f"Please have a close look"
                     )
-            # taking care of dimension doc
+            # Taking care of dimension doc
             dimension_doc = ""
             for child in list(node):
                 tag = remove_namespace_from_tag(child.tag)
@@ -887,7 +882,7 @@ class Nxdl2yaml:
         # Maintain order: name and type in form name(type) or (type)name that come first
         name = node_attr.pop(nm_attr, "")
         if not name:
-            raise ValueError("Attribute must have an name key.")
+            raise ValueError("Attribute must have a name key.")
 
         indent = depth * DEPTH_SIZE
         escapesymbol = r"\@"

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -711,7 +711,7 @@ class Nxdl2yaml:
 
         def handle_dim_with_all_dim_attr(depth, node, file_out, possible_dim_attrs):
             """Handle the dim if it has other attributes along with value and index"""
-            dim_index_value = ""
+            dim_index_value = []
             dim_other_parts = {}
             dim_cmnt_nodes = []
             # Taking care of dim and doc children of dimension
@@ -721,10 +721,10 @@ class Nxdl2yaml:
                 # taking care of index and value attributes
                 if tag == "dim":
                     # taking care of index and value in format [[index, value]]
-                    index = child_attrs.pop("index", "")
+                    # index = child_attrs.pop("index", "")
                     value = child_attrs.pop("value", "")
-                    dim_index_value = f"{dim_index_value}[{index}, {value}], "
-
+                    # dim_index_value = f"{dim_index_value}[{index}, {value}], "
+                    dim_index_value.append(value)
                     # Taking care of doc comes as child of dim
                     for cchild in list(child):
                         ttag = cchild.tag.split("}", 1)[1]
@@ -754,8 +754,12 @@ class Nxdl2yaml:
             # index and value attributes of dim elements
             indent = (depth + 1) * DEPTH_SIZE
             # Numpy style for dim
-            value = dim_index_value[:-2] or ""
-            file_out.write(f"{indent}dim: [{value}]\n")
+            value = (
+                ", ".join(dim_index_value)
+                if len(dim_index_value) > 1
+                else f"{dim_index_value[0]},"
+            )
+            file_out.write(f"{indent}dim: ({value})\n")
 
             # Write the attributes, except index and value, and doc of dim as child of dim_parameter.
             # But the doc or attributes for each dim come inside list according to the order of dim.

--- a/tests/data/Ref_NXcomment.yaml
+++ b/tests/data/Ref_NXcomment.yaml
@@ -28,11 +28,14 @@ NXmpes:
     exists: recommended
     # 9: Title comment
     title:
-    # 10: Group comment
+    # 10: Field comment
     start_time(NX_DATE_TIME):
       doc: "Datetime of the start of the measurement."
+      # 11: dim comments:
+      #  dim comments:
+      dim: (1, 2, 6)
     definition:
-      # 11: version_attribute: comments hrere
+      # 12: version_attribute: comments hrere
       \@version:
       enumeration: ["NXmpes"]
     # 12: Scond comment for Comment NXdata(data)
@@ -43,6 +46,7 @@ NXmpes:
     # 14: Third comment for Comment NXdata(data)
     (NXdata)data:
      # 15: comment (energy(link)):
+     # A comment for energy(link)
       energy(link):
         target: /entry/instrument/fluorescence/energy
      # 16: comment (data(link)):
@@ -59,10 +63,10 @@ NXmpes:
           # 19: dim comments:
           dim: [[1, 2]]
 
-  # 20: File endgin comments
-  # 20: File ending comments
-  # 20: File ending comments
+  # 22: File endgin comments
+  # 22: File ending comments
+  # 22: File ending comments
 
-  # 21: File endgin comments
-  # 21: File ending comments
-  # 21: File ending comments
+  # 23: File endgin comments
+  # 23: File ending comments
+  # 23: File ending comments

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -12,3 +12,12 @@ NXarchive(NXobject):
       dimensions:
         rank: 1
         dim: [[1, 2]]
+    my_dim_with_numpy_3d(NX_NUMBER):
+      dim: (2, 4, 5)
+    my_dim_with_doc_and_dim_attr(NX_NUMBER):
+      dimensions:
+        doc: |
+          Test with doc and dim attribute
+        dim: [[1, 2], [3, 4]]
+        dim_parameters:
+          ref: ['s', 'm']

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -11,7 +11,7 @@ NXarchive(NXobject):
       doc: Testarray with dimensions spelled out
       dimensions:
         rank: 1
-        dim: [[1, 2]]
+        dim: (10, 30)
     my_dim_with_numpy_3d(NX_NUMBER):
       dim: (2, 4, 5)
     my_dim_with_doc_and_dim_attr(NX_NUMBER):

--- a/tests/data/dimensions.nxdl.xml
+++ b/tests/data/dimensions.nxdl.xml
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         This is a test for the dimension keywords.
+    </doc>
+    <group type="NXentry">
+        <field name="my_dim_array" type="NX_NUMBER">
+            <doc>
+                 Test
+            </doc>
+            <dimensions>
+                <dim index="1" value="2"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_array2" type="NX_NUMBER">
+            <doc>
+                 Testarray with dimensions spelled out
+            </doc>
+            <dimensions rank="1">
+                <dim index="1" value="10"/>
+                <dim index="2" value="30"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_with_numpy_3d" type="NX_NUMBER">
+            <dimensions>
+                <dim index="1" value="2"/>
+                <dim index="2" value="4"/>
+                <dim index="3" value="5"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                     Test with doc and dim attribute
+                </doc>
+                <dim index="1" value="2" ref="s"/>
+                <dim index="3" value="4" ref="m"/>
+            </dimensions>
+        </field>
+    </group>
+</definition>

--- a/tests/data/dimensions.nxdl.xml
+++ b/tests/data/dimensions.nxdl.xml
@@ -38,7 +38,7 @@
             <doc>
                  Testarray with dimensions spelled out
             </doc>
-            <dimensions rank="1">
+            <dimensions>
                 <dim index="1" value="10"/>
                 <dim index="2" value="30"/>
             </dimensions>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -30,7 +30,7 @@
             <doc>
                  Test
             </doc>
-            <dimensions rank="1">
+            <dimensions>
                 <dim index="1" value="2"/>
             </dimensions>
         </field>
@@ -40,6 +40,22 @@
             </doc>
             <dimensions rank="1">
                 <dim index="1" value="2"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_with_numpy_3d" type="NX_NUMBER">
+            <dimensions>
+                <dim index="1" value="2"/>
+                <dim index="2" value="4"/>
+                <dim index="3" value="5"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                     Test with doc and dim attribute
+                </doc>
+                <dim index="1" value="2" ref="s"/>
+                <dim index="3" value="4" ref="m"/>
             </dimensions>
         </field>
     </group>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -39,7 +39,8 @@
                  Testarray with dimensions spelled out
             </doc>
             <dimensions rank="1">
-                <dim index="1" value="2"/>
+                <dim index="1" value="10"/>
+                <dim index="2" value="30"/>
             </dimensions>
         </field>
         <field name="my_dim_with_numpy_3d" type="NX_NUMBER">

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -1,0 +1,25 @@
+category: application
+doc: |
+  This is a test for the dimension keywords.
+type: group
+NXarchive(NXobject):
+  (NXentry):
+    my_dim_array(NX_NUMBER):
+      doc: |
+        Test
+      dim: (2,)
+    my_dim_array2(NX_NUMBER):
+      doc: |
+        Testarray with dimensions spelled out
+      dimensions:
+        rank: 1
+        dim: (10, 30)
+    my_dim_with_numpy_3d(NX_NUMBER):
+      dim: (2, 4, 5)
+    my_dim_with_doc_and_dim_attr(NX_NUMBER):
+      dimensions:
+        doc: |
+          Test with doc and dim attribute
+        dim: (2, 4)
+        dim_parameters:
+          ref: ['s', 'm']

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -11,9 +11,7 @@ NXarchive(NXobject):
     my_dim_array2(NX_NUMBER):
       doc: |
         Testarray with dimensions spelled out
-      dimensions:
-        rank: 1
-        dim: (10, 30)
+      dim: (10, 30)
     my_dim_with_numpy_3d(NX_NUMBER):
       dim: (2, 4, 5)
     my_dim_with_doc_and_dim_attr(NX_NUMBER):

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -498,7 +498,7 @@ def test_nyaml2nxdl_dim_keyword(tmp_path):
 
 def test_nxdl2yaml_dimensions(tmp_path):
     """
-    Test the proper conversion of nxdl2yaml with dimension and dim keyword.
+    Test the proper conversion of nxdl2yaml with dimension and dim keywords.
     """
 
     pwd = Path(__file__).parent
@@ -513,10 +513,9 @@ def test_nxdl2yaml_dimensions(tmp_path):
 
     assert result.exit_code == 0, "Error in converter execution."
     # read yaml files
-    with (
-        open(ref_file, mode="r", encoding="utf-8") as ref_yaml,
-        open(parsed_file, mode="r", encoding="utf-8") as parsed_yaml,
-    ):
+    with open(ref_file, mode="r", encoding="utf-8") as ref_yaml, open(
+        parsed_file, mode="r", encoding="utf-8"
+    ) as parsed_yaml:
         ref_yaml_dict = LineLoader(ref_yaml).get_single_data()
         parsed_yaml_dict = LineLoader(parsed_yaml).get_single_data()
 


### PR DESCRIPTION
Conversions from yaml to nxdl and vice-versa.
```yaml
dim: (4,5)
```
```xml
<dimensions>
    <dim index=1 value=4/>
    <dim index=2 value=5/>
<dimensions/>
```
Note, the `<dimension>` does not have any `rank` which is intended. To keep the consistency (which was also part motivation of nyaml2nxdl tools) a of the `nxdl.xml` file content, e.g. if a `nxdl.xml` file `dimension` element does not have any `rank` key while reproducing the `nxdl.xml` the `dimensions` element will be as it was.

- [x] Add test file as Lukas suggested.
- [x] Implement markus suggestions.
- [x] Add both of the notations
```yaml
dimensions:
   rank: 3
   dim: (2, 4, 5)
   dim_parameters:
      doc: ["index_1","index_2", ,"index_3"]
```
```yaml
dimensions:
   rank: 3
   dim: (2, 4, 5)
   dim_parameters:
      doc: ["index_1","index_2", ,"index_3"]
```