### PR TITLE
Dimensions in NXDL always get a rank

### DIFF
--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -749,12 +749,17 @@ class Nxdl2yaml:
             # index and value attributes of dim elements
             indent = (depth + 1) * DEPTH_SIZE
             # Numpy style for dim
-            value = (
-                ", ".join(dim_index_value)
-                if len(dim_index_value) > 1
-                else f"{dim_index_value[0]},"
-            )
-            file_out.write(f"{indent}dim: ({value})\n")
+            if dim_index_value:
+                value = (
+                    ", ".join(dim_index_value)
+                    if len(dim_index_value) > 1
+                    else f"{dim_index_value[0]},"
+                )
+                value = f"({value})"
+            else:
+                # if dim is empty
+                value = []
+            file_out.write(f"{indent}dim: {value}\n")
 
             # Write the attributes, except index and value, and doc of dim as child of dim_parameters.
             # But the doc or attributes for each dim come inside list according to the order of dim.

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -669,7 +669,7 @@ class Nxdl2yaml:
         def handle_dim_with_value_and_index(depth, node, file_out, dimension_doc):
             """
             Handle <dimensions> element if <dim> has only value and index attributes, and
-            <diemensions> element has only one attribute 'rank', but no doc."""
+            <dimensions> element has only one attribute 'rank', but no doc."""
             indent = depth * DEPTH_SIZE
             dim_index_value = ""
             dim_cmnt_nodes = []
@@ -776,21 +776,21 @@ class Nxdl2yaml:
                             f"{handle_mapping_char(value, depth + 3, False)}\n"
                         )
 
+        # Check that dimension only has valid attributes.
+        for attr in node.attrib.keys():
+            if attr not in possible_dimension_attrs:
+                raise ValueError(
+                    f"Dimension has an attribute {attr} that is not valid."
+                    f"Currently allowed attributes are {possible_dimension_attrs}."
+                    f"Please have a close look"
+                )
+
         # Dimension has other attributes including index and value
-        if remove_namespace_from_tag(node[0].tag) == "doc" or len(node.attrib) > 0:
+        if remove_namespace_from_tag(node[0].tag) == "doc":
             indent = depth * DEPTH_SIZE
             tag = remove_namespace_from_tag(node.tag)
             file_out.write(f"{indent}{tag}:\n")
-            for attr, value in node.attrib.items():
-                if attr in possible_dimension_attrs and not isinstance(value, dict):
-                    indent = (depth + 1) * DEPTH_SIZE
-                    file_out.write(f"{indent}{attr}: {value}\n")
-                else:
-                    raise ValueError(
-                        f"Dimension has an attribute {attr} that is not valid."
-                        f"Currently allowed attributes are {possible_dimension_attrs}."
-                        f"Please have a close look"
-                    )
+
             # Taking care of dimension doc
             dimension_doc = ""
             for child in list(node):

--- a/nyaml/nxdl2nyaml.py
+++ b/nyaml/nxdl2nyaml.py
@@ -780,8 +780,8 @@ class Nxdl2yaml:
         for attr in node.attrib.keys():
             if attr not in possible_dimension_attrs:
                 raise ValueError(
-                    f"Dimension has an attribute {attr} that is not valid."
-                    f"Currently allowed attributes are {possible_dimension_attrs}."
+                    f"Dimension has an attribute {attr} that is not valid. "
+                    f"Currently allowed attributes are {possible_dimension_attrs}. "
                     f"Please have a close look"
                 )
 

--- a/nyaml/nyaml2nxdl.py
+++ b/nyaml/nyaml2nxdl.py
@@ -479,7 +479,7 @@ def xml_handle_dim(dct, obj, keyword, value):
                     valid_dims.append(entry)
             if len(valid_dims) > 0:
                 dims = ET.SubElement(obj, "dimensions")
-                # dims.set("rank", str(len(valid_dims)))
+                dims.set("rank", str(len(valid_dims)))
                 dim_idx = 1
                 for dim_name in valid_dims:
                     dim = ET.SubElement(dims, "dim")

--- a/tests/data/Ref_NXcomment.yaml
+++ b/tests/data/Ref_NXcomment.yaml
@@ -1,72 +1,88 @@
-
 category: application
 
 # 1: Pincelli, Rettig, Arora at fhi-berlin.mpg.de, Dobener at hu-berlin.de, 06/2022
-#Draft version of a NeXus application definition for photoemission,
-#It is designed to be extended by other application definitions
-#with higher granularity in the data description.
+# Draft version of a NeXus application definition for photoemission,
+# It is designed to be extended by other application definitions
+# with higher granularity in the data description.
+doc: |
+  This is the most general application definition for multidimensional
+  photoelectron spectroscopy.
 
-doc: This is the most general application definition for multidimensional photoelectron spectroscopy.
 # 2: symbols comments: comments here
 symbols:
-# 3: symbols doc comments
+
+  # 3: symbols doc comments
   doc: |
     symbols doc
-# 4: symbol comments: comments here
-  n_different_temperatures: "Number of different temperature setpoints used in the experiment."
-# 5: symbol comments: comments here
-  n_different_voltages: "Number of different voltage setpoints used in the experiment."
 
-# 6: NXmpes: Test -- documentation
+  # 4: symbol comments: comments here
+  n_different_temperatures: |
+    Number of different temperature setpoints used in the experiment.
+
+  # 5: symbol comments: comments here
+  n_different_voltages: |
+    Number of different voltage setpoints used in the experiment.
+
+# 6: NXmpes: Test -\- documentation
 # NXmpes: Test documentation
-NXmpes:
+type: group
+NXmpes(NXobject):
+  
   # 7: NXmpes: Test documentation
   # NXmpes: Test documentation
-
+  
   # 8: exists: comment
   (NXentry):
     exists: recommended
+    
     # 9: Title comment
     title:
+    
     # 10: Field comment
     start_time(NX_DATE_TIME):
-      doc: "Datetime of the start of the measurement."
+      doc: |
+        Datetime of the start of the measurement.
+      
       # 11: dim comments:
-      #  dim comments:
+      # dim comments:
       dim: (1, 2, 6)
     definition:
+      
       # 12: version_attribute: comments hrere
       \@version:
-      enumeration: ["NXmpes"]
+      enumeration: [NXmpes]
+    
     # 12: Scond comment for Comment NXdata(data)
-
+    
     # 13: comment nxdata(data): comments
     # comment nxdata(data): comments
-
+    
     # 14: Third comment for Comment NXdata(data)
     (NXdata)data:
-     # 15: comment (energy(link)):
-     # A comment for energy(link)
+      
+      # 15: comment (energy(link)):
+      # A comment for energy(link)
       energy(link):
         target: /entry/instrument/fluorescence/energy
-     # 16: comment (data(link)):
+      
+      # 16: comment (data(link)):
       data(link):
         target: /entry/instrument/fluorescence/data
       region_origin(NX_INT):
         doc: |
           origin of rectangular region selected for readout
+        
         # 17: dimensions comments:
-
+        
         # 18: rank comments: comments
-        dimensions:
-          rank: 1
-          # 19: dim comments:
-          dim: [[1, 2]]
-
+        
+        # 19: dim comments:
+        dim: (2,)
+  
   # 22: File endgin comments
   # 22: File ending comments
   # 22: File ending comments
-
+  
   # 23: File endgin comments
   # 23: File ending comments
   # 23: File ending comments

--- a/tests/data/Ref_NXentry.yaml
+++ b/tests/data/Ref_NXentry.yaml
@@ -57,7 +57,7 @@ NXentry(NXobject):
   (NXsubentry):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 6e5f16c6d106f3b59aa4df6a9f254e1ba2041ed235e1f4377d7788adcb8f01a9
+# 4d3957dd863d0307a70837558b6f6d88ab6a089e37f33dd7f58ca0e1da8e13bf
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 # <definition name="NXentry" 

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -30,10 +30,10 @@ NXarchive(NXobject):
         dim_parameters:
           ref: ['s', 'm']
     my_dim_without_value(NX_NUMBER):
-      doc: |
-        Test with dimension, dim, and no value,
-        as in NXsensor/value_deriv2.
       dimensions:
+        doc: |
+          Test with dimension, dim, and no value,
+          as in NXsensor/value_deriv2.
         dim: [[1, ]]
         dim_parameters:
           ref: ['value']

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -29,3 +29,12 @@ NXarchive(NXobject):
         dim: (2, 4)
         dim_parameters:
           ref: ['s', 'm']
+    my_dim_without_value(NX_NUMBER):
+      doc: |
+        Test with dimension, dim, and no value,
+        as in NXsensor/value_deriv2.
+      dimensions:
+        dim: [[1, ]]
+        dim_parameters:
+          ref: ['value']
+

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -10,14 +10,22 @@ NXarchive(NXobject):
     my_dim_array2(NX_NUMBER):
       doc: Testarray with dimensions spelled out
       dimensions:
-        rank: 1
+        rank: 2
         dim: (10, 30)
     my_dim_with_numpy_3d(NX_NUMBER):
       dim: (2, 4, 5)
-    my_dim_with_doc_and_dim_attr(NX_NUMBER):
+    my_dim_with_doc_rank_and_dim_attr(NX_NUMBER):
       dimensions:
         doc: |
           Test with doc and dim attribute
+        rank: 2
         dim: [[1, 2], [3, 4]]
+        dim_parameters:
+          ref: ['s', 'm']
+    my_dim_with_doc_and_short_dim_attr(NX_NUMBER):
+      dimensions:
+        doc: |
+          Test with doc and dim attribute
+        dim: (2, 4)
         dim_parameters:
           ref: ['s', 'm']

--- a/tests/data/dim_keyword.yaml
+++ b/tests/data/dim_keyword.yaml
@@ -33,7 +33,7 @@ NXarchive(NXobject):
       dimensions:
         doc: |
           Test with dimension, dim, and no value,
-          as in NXsensor/value_deriv2.
+          as in NXsensor/value_deriv1.
         dim: [[1, ]]
         dim_parameters:
           ref: ['value']

--- a/tests/data/dimensions.nxdl.xml
+++ b/tests/data/dimensions.nxdl.xml
@@ -43,6 +43,13 @@
                 <dim index="2" value="30"/>
             </dimensions>
         </field>
+        <field name="my_dim_without_dimension" type="NX_NUMBER">
+            <dimensions rank="dataRank">
+                <doc>
+                     Dim without dimension.
+                </doc>
+            </dimensions>
+        </field>
         <field name="my_dim_with_numpy_3d" type="NX_NUMBER">
             <dimensions rank="3">
                 <dim index="1" value="2"/>

--- a/tests/data/dimensions.nxdl.xml
+++ b/tests/data/dimensions.nxdl.xml
@@ -30,7 +30,7 @@
             <doc>
                  Test
             </doc>
-            <dimensions>
+            <dimensions rank="1">
                 <dim index="1" value="2"/>
             </dimensions>
         </field>
@@ -38,22 +38,31 @@
             <doc>
                  Testarray with dimensions spelled out
             </doc>
-            <dimensions>
+            <dimensions rank="2">
                 <dim index="1" value="10"/>
                 <dim index="2" value="30"/>
             </dimensions>
         </field>
         <field name="my_dim_with_numpy_3d" type="NX_NUMBER">
-            <dimensions>
+            <dimensions rank="3">
                 <dim index="1" value="2"/>
                 <dim index="2" value="4"/>
                 <dim index="3" value="5"/>
             </dimensions>
         </field>
         <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
-            <dimensions>
+            <dimensions rank="2">
                 <doc>
                      Test with doc and dim attribute
+                </doc>
+                <dim index="1" value="2" ref="s"/>
+                <dim index="3" value="4" ref="m"/>
+            </dimensions>
+        </field>
+        <field name="my_dimensions_without_rank" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                        Test with doc and dim attribute
                 </doc>
                 <dim index="1" value="2" ref="s"/>
                 <dim index="3" value="4" ref="m"/>

--- a/tests/data/dimensions.nxdl.xml
+++ b/tests/data/dimensions.nxdl.xml
@@ -60,7 +60,7 @@
         <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
             <dimensions rank="2">
                 <doc>
-                     Test with doc and dim attribute
+                        Test with doc and dim attribute
                 </doc>
                 <dim index="1" value="2" ref="s"/>
                 <dim index="3" value="4" ref="m"/>
@@ -73,6 +73,15 @@
                 </doc>
                 <dim index="1" value="2" ref="s"/>
                 <dim index="3" value="4" ref="m"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_without_value" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                    Test with dimension, dim, and no value,
+                    as in NXsensor/value_deriv2.
+                </doc>
+                <dim index="1" ref="value"/>
             </dimensions>
         </field>
     </group>

--- a/tests/data/dimensions_with_wrong_attribs.nxdl.xml
+++ b/tests/data/dimensions_with_wrong_attribs.nxdl.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <doc>
+         This is a test for the dimension keywords.
+    </doc>
+    <group type="NXentry">
+        <field name="my_dim_array" type="NX_NUMBER">
+            <doc>
+                 Test
+            </doc>
+            <dimensions rank="1" wrong_attrib="test">
+                <dim index="1" value="2"/>
+            </dimensions>
+        </field>
+    </group>
+</definition>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -60,7 +60,7 @@
             </dimensions>
         </field>
         <field name="my_dim_with_doc_and_short_dim_attr" type="NX_NUMBER">
-            <dimensions>
+            <dimensions rank="2">
                 <doc>
                      Test with doc and dim attribute
                 </doc>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -68,5 +68,14 @@
                 <dim index="2" value="4" ref="m"/>
             </dimensions>
         </field>
+        <field name="my_dim_without_value" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                    Test with dimension, dim, and no value,
+                    as in NXsensor/value_deriv2.                   
+                </doc>
+                <dim index="1" ref="value"/>
+            </dimensions>
+        </field>
     </group>
 </definition>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -38,7 +38,7 @@
             <doc>
                  Testarray with dimensions spelled out
             </doc>
-            <dimensions rank="1">
+            <dimensions rank="2">
                 <dim index="1" value="10"/>
                 <dim index="2" value="30"/>
             </dimensions>
@@ -50,13 +50,22 @@
                 <dim index="3" value="5"/>
             </dimensions>
         </field>
-        <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
-            <dimensions>
+        <field name="my_dim_with_doc_rank_and_dim_attr" type="NX_NUMBER">
+            <dimensions rank="2">
                 <doc>
                      Test with doc and dim attribute
                 </doc>
                 <dim index="1" value="2" ref="s"/>
                 <dim index="3" value="4" ref="m"/>
+            </dimensions>
+        </field>
+        <field name="my_dim_with_doc_and_short_dim_attr" type="NX_NUMBER">
+            <dimensions>
+                <doc>
+                     Test with doc and dim attribute
+                </doc>
+                <dim index="1" value="2" ref="s"/>
+                <dim index="2" value="4" ref="m"/>
             </dimensions>
         </field>
     </group>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -72,7 +72,7 @@
             <dimensions>
                 <doc>
                     Test with dimension, dim, and no value,
-                    as in NXsensor/value_deriv2.                   
+                    as in NXsensor/value_deriv1.
                 </doc>
                 <dim index="1" ref="value"/>
             </dimensions>

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -30,7 +30,7 @@
             <doc>
                  Test
             </doc>
-            <dimensions>
+            <dimensions rank="1">
                 <dim index="1" value="2"/>
             </dimensions>
         </field>
@@ -44,7 +44,7 @@
             </dimensions>
         </field>
         <field name="my_dim_with_numpy_3d" type="NX_NUMBER">
-            <dimensions>
+            <dimensions rank="3">
                 <dim index="1" value="2"/>
                 <dim index="2" value="4"/>
                 <dim index="3" value="5"/>

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -33,3 +33,11 @@ NXarchive(NXobject):
         dim: (2, 4)
         dim_parameters:
           ref: ['s', 'm']
+    my_dim_without_value(NX_NUMBER):
+    doc: |
+      Test with dimension, dim, and no value,
+      as in NXsensor/value_deriv2.
+    dimensions:
+      dim: [[1, ]]
+      dim_parameters:
+        ref: ['value']

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -34,10 +34,10 @@ NXarchive(NXobject):
         dim_parameters:
           ref: ['s', 'm']
     my_dim_without_value(NX_NUMBER):
-    doc: |
-      Test with dimension, dim, and no value,
-      as in NXsensor/value_deriv2.
-    dimensions:
-      dim: [[1, ]]
-      dim_parameters:
-        ref: ['value']
+      dimensions:
+        doc: |
+          Test with dimension, dim, and no value,
+          as in NXsensor/value_deriv2.  
+        dim: [[1, ]]
+        dim_parameters:
+          ref: ['value']

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -21,3 +21,10 @@ NXarchive(NXobject):
         dim: (2, 4)
         dim_parameters:
           ref: ['s', 'm']
+    my_dimensions_without_rank(NX_NUMBER):
+      dimensions:
+        doc: |
+          Test with doc and dim attribute
+        dim: (2, 4)
+        dim_parameters:
+          ref: ['s', 'm']

--- a/tests/data/ref_dimensions.yaml
+++ b/tests/data/ref_dimensions.yaml
@@ -12,6 +12,11 @@ NXarchive(NXobject):
       doc: |
         Testarray with dimensions spelled out
       dim: (10, 30)
+    my_dim_without_dimension(NX_NUMBER):
+      dimensions:
+        doc: |
+          Dim without dimension.
+        dim: []
     my_dim_with_numpy_3d(NX_NUMBER):
       dim: (2, 4, 5)
     my_dim_with_doc_and_dim_attr(NX_NUMBER):

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -151,7 +151,7 @@ def test_nxdl2yaml_doc_format_and_nxdl_part_as_comment():
 
     result = filecmp.cmp(ref_yml_file, test_yml_file, shallow=False)
     assert result, "Ref YML and parsed YML\
-has not the same structure!!"
+don't have the same structure!!"
     os.remove(test_yml_file)
     sys.stdout.write("Test on xml -> yml doc formatting okay.\n")
 
@@ -520,6 +520,29 @@ def test_nxdl2nyaml_dimensions(tmp_path):
         parsed_yaml_dict = LineLoader(parsed_yaml).get_single_data()
 
     compare_yaml_content(ref_yaml_dict, parsed_yaml_dict, ["dimensions", "dim"])
+
+
+def test_nxdl2yaml_dimensions_with_wrong_attrib():
+    """
+    Test that an ndxdl node with dimensions and a wrong attritues does not convert
+    properly.
+    """
+
+    pwd = Path(__file__).parent
+    input_file = pwd / "data/dimensions_with_wrong_attribs.nxdl.xml"
+    parsed_file = pwd / "data/dimensions_with_wrong_attribs_parsed.yaml"
+
+    result = CliRunner().invoke(
+        nyaml2nxdl.launch_tool,
+        ["--do-not-store-nxdl", str(input_file)],
+    )
+
+    assert isinstance(result.exception, ValueError)
+    assert (
+        "Dimension has an attribute wrong_attrib that is not valid. Currently allowed attributes are ['rank']. Please have a close look"
+        in str(result.exception)
+    )
+    os.remove(parsed_file)
 
 
 def test_yaml2nxdl_no_tabs(tmp_path):

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -496,7 +496,7 @@ def test_nyaml2nxdl_dim_keyword(tmp_path):
     assert ref_file.read_text() == parsed_file.read_text()
 
 
-def test_nxdl2yaml_dimensions(tmp_path):
+def test_nxdl2nyaml_dimensions(tmp_path):
     """
     Test the proper conversion of nxdl2yaml with dimension and dim keywords.
     """


### PR DESCRIPTION
- [x] Dimensions in NXDL always get a rank when converting from nyaml to nxdl
- [x] Added test for wrong dimensions attribute (i.e., attribute that is not `rank`)
- [x] Updated test cases
- [x] Always use shortcut `dim` notation in nyaml
  - either directly as `dim: (2,4)`
  - or within dimensions: 
    ```yaml
    dimensions:
      doc: |
        Test with doc and dim attribute
      dim: (2, 4)
      dim_parameters:
        ref: ['s', 'm']
    ```