### PR TITLE
consistent 4 whitespaces for docs

### DIFF
--- a/src/nyaml/nyaml2nxdl.py
+++ b/src/nyaml/nyaml2nxdl.py
@@ -1158,7 +1158,7 @@ def pretty_print_xml(xml_root, output_xml, def_comments=None):
                     white_spaces = len(i) - len(i.lstrip())
                     file_out_mod.write(i)
                 elif "<doc>" not in i and "</doc>" not in i and flag is True:
-                    file_out_mod.write((white_spaces + 5) * " " + i)
+                    file_out_mod.write((white_spaces + 4) * " " + i)
                 elif "<doc>" not in i and "</doc>" in i and flag is True:
                     file_out_mod.write(white_spaces * " " + i)
                     flag = False

--- a/tests/data/Ref_NXcomment_yaml2nxdl.nxdl.xml
+++ b/tests/data/Ref_NXcomment_yaml2nxdl.nxdl.xml
@@ -28,18 +28,18 @@ NXmpes: Test documentation-->
     <symbols>
         <!--3: symbols doc comments-->
         <doc>
-             symbols doc
+            symbols doc
         </doc>
         <!--4: symbol comments: comments here-->
         <symbol name="n_different_temperatures">
             <doc>
-                 Number of different temperature setpoints used in the experiment.
+                Number of different temperature setpoints used in the experiment.
             </doc>
         </symbol>
         <!--5: symbol comments: comments here-->
         <symbol name="n_different_voltages">
             <doc>
-                 Number of different voltage setpoints used in the experiment.
+                Number of different voltage setpoints used in the experiment.
             </doc>
         </symbol>
     </symbols>
@@ -48,8 +48,8 @@ Draft version of a NeXus application definition for photoemission,
 It is designed to be extended by other application definitions
 with higher granularity in the data description.-->
     <doc>
-         This is the most general application definition for multidimensional
-         photoelectron spectroscopy.
+        This is the most general application definition for multidimensional
+        photoelectron spectroscopy.
     </doc>
     <!--7: NXmpes: Test documentation
 NXmpes: Test documentation
@@ -60,7 +60,7 @@ NXmpes: Test documentation
         <!--10: Group comment-->
         <field name="start_time" type="NX_DATE_TIME">
             <doc>
-                 Datetime of the start of the measurement.
+                Datetime of the start of the measurement.
             </doc>
         </field>
         <field name="definition">
@@ -81,7 +81,7 @@ comment nxdata(data): comments-->
             <link name="data" target="/entry/instrument/fluorescence/data"/>
             <field name="region_origin" type="NX_INT">
                 <doc>
-                     origin of rectangular region selected for readout
+                    origin of rectangular region selected for readout
                 </doc>
                 <!--17: dimensions comments:-->
                 <!--18: rank comments: comments-->

--- a/tests/data/ref_dim_keyword.nxdl.xml
+++ b/tests/data/ref_dim_keyword.nxdl.xml
@@ -23,12 +23,12 @@
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         This is a test for the dimension keywords.
+        This is a test for the dimension keywords.
     </doc>
     <group type="NXentry">
         <field name="my_dim_array" type="NX_NUMBER">
             <doc>
-                 Test
+                Test
             </doc>
             <dimensions>
                 <dim index="1" value="2"/>
@@ -36,7 +36,7 @@
         </field>
         <field name="my_dim_array2" type="NX_NUMBER">
             <doc>
-                 Testarray with dimensions spelled out
+                Testarray with dimensions spelled out
             </doc>
             <dimensions rank="1">
                 <dim index="1" value="10"/>
@@ -45,7 +45,7 @@
         </field>
         <field name="my_dim_array3" type="NX_NUMBER">
             <doc>
-                 Testarray with dimensions spelled out
+                Testarray with dimensions spelled out
             </doc>
             <dimensions rank="1">
                 <dim index="1" value="10"/>
@@ -61,7 +61,7 @@
         <field name="my_dim_with_doc_and_dim_attr" type="NX_NUMBER">
             <dimensions>
                 <doc>
-                     Test with doc and dim attribute
+                    Test with doc and dim attribute
                 </doc>
                 <dim index="1" value="2" ref="s"/>
                 <dim index="3" value="4" ref="m"/>

--- a/tests/data/ref_doc_yaml2nxdl.nxdl.xml
+++ b/tests/data/ref_doc_yaml2nxdl.nxdl.xml
@@ -23,54 +23,54 @@
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXarchive" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <doc>
-         This is a definition for data to be archived by ICAT (http://www.icatproject.org/).
-         
-         .. text from the icatproject.org site
-         
-                 the database (with supporting software) that provides an
-                 interface to all ISIS experimental data and will provide
-                 a mechanism to link all aspects of ISIS research from
-                 proposal through to publication.
-         
-         This concept is related to term `1.1`_ of the ISO 18115-1:2023 standard.
-         
-         .. _1.1: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:1.1
+        This is a definition for data to be archived by ICAT (http://www.icatproject.org/).
+        
+        .. text from the icatproject.org site
+        
+                the database (with supporting software) that provides an
+                interface to all ISIS experimental data and will provide
+                a mechanism to link all aspects of ISIS research from
+                proposal through to publication.
+        
+        This concept is related to term `1.1`_ of the ISO 18115-1:2023 standard.
+        
+        .. _1.1: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:1.1
     </doc>
     <group type="NXentry" name="entry">
         <attribute name="index"/>
         <field name="title"/>
         <field name="experiment_identifier" type="NX_CHAR">
             <doc>
-                 "unique identifier for the experimenta
-                   lkokö
-                   sddfdfd"
-                 
-                 This concept is related to term `12.58`_ of the ISO 18115-1:2023 standard.
-                 
-                 .. _12.58: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58
-                 
-                 "This is test doc."
+                "unique identifier for the experimenta
+                  lkokö
+                  sddfdfd"
+                
+                This concept is related to term `12.58`_ of the ISO 18115-1:2023 standard.
+                
+                .. _12.58: https://www.iso.org/obp/ui/en/#iso:std:iso:18115:-1:ed-3:v1:en:term:12.58
+                
+                "This is test doc."
             </doc>
         </field>
         <field name="experiment_description" type="NX_CHAR">
             <doc>
-                 Part1: Text line 1.
-                 part1: Text line 2
-                 
-                 This concept is related to term `term`_ of the spec standard.
-                 
-                 .. _term: url
+                Part1: Text line 1.
+                part1: Text line 2
+                
+                This concept is related to term `term`_ of the spec standard.
+                
+                .. _term: url
             </doc>
         </field>
         <field name="collection_identifier" type="NX_CHAR">
             <doc>
-                 ID of user or DAQ define group of data files
-                 Brief summary of the collection, including grouping criteria
+                ID of user or DAQ define group of data files
+                Brief summary of the collection, including grouping criteria
             </doc>
         </field>
         <field name="entry_identifier" type="NX_CHAR">
             <doc>
-                 unique identifier for this measurement as provided by the facility
+                unique identifier for this measurement as provided by the facility
             </doc>
         </field>
         <field name="start_time" type="NX_DATE_TIME"/>

--- a/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
+++ b/tests/data/ref_no_tabs_yaml2nxdl.nxdl.xml
@@ -24,60 +24,60 @@
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" ignoreExtraFields="true" ignoreExtraAttributes="true" name="NXtest" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
     <symbols>
         <doc>
-             These symbols will be used below to coordinate fields with the same
-             shape.
+            These symbols will be used below to coordinate fields with the same
+            shape.
         </doc>
         <symbol name="dataRank">
             <doc>
-                 rank of the ``DATA`` field
+                rank of the ``DATA`` field
             </doc>
         </symbol>
         <symbol name="n">
             <doc>
-                 length of the ``AXISNAME`` field
+                length of the ``AXISNAME`` field
             </doc>
         </symbol>
         <symbol name="nx">
             <doc>
-                 length of the ``x`` field
+                length of the ``x`` field
             </doc>
         </symbol>
         <symbol name="ny">
             <doc>
-                 length of the ``y`` field
+                length of the ``y`` field
             </doc>
         </symbol>
         <symbol name="nz">
             <doc>
-                 length of the ``z`` field
+                length of the ``z`` field
             </doc>
         </symbol>
     </symbols>
     <doc>
-         * Each :ref:`NXdata` group will define one field as the default
-           plottable data.  The value of the ``signal`` attribute names this field.
-           Additional fields may be used to describe the dimension scales and
-           uncertainities.
-           The ``auxiliary_signals`` attribute is a list of the other fields
-           to be plotted with the ``signal`` data.
-         * The plottable data may be of arbitrary rank up to a maximum
-           of ``NX_MAXRANK=32`` (for compatibility with backend file formats).
-         * The plottable data will be named as the value of
-           the group ``signal`` attribute, such as::
-         
-             data:NXdata
-               @signal = "counts"
-               @axes = "mr"
-               @mr_indices = 0
-               counts: float[100]  --&gt; the default dependent data
-               mr: float[100]  --&gt; the default independent data
-         
-           The field named in the ``signal`` attribute **must** exist, either
-           directly as a NeXus field or defined through a link.
+        * Each :ref:`NXdata` group will define one field as the default
+          plottable data.  The value of the ``signal`` attribute names this field.
+          Additional fields may be used to describe the dimension scales and
+          uncertainities.
+          The ``auxiliary_signals`` attribute is a list of the other fields
+          to be plotted with the ``signal`` data.
+        * The plottable data may be of arbitrary rank up to a maximum
+          of ``NX_MAXRANK=32`` (for compatibility with backend file formats).
+        * The plottable data will be named as the value of
+          the group ``signal`` attribute, such as::
+        
+            data:NXdata
+              @signal = "counts"
+              @axes = "mr"
+              @mr_indices = 0
+              counts: float[100]  --&gt; the default dependent data
+              mr: float[100]  --&gt; the default independent data
+        
+          The field named in the ``signal`` attribute **must** exist, either
+          directly as a NeXus field or defined through a link.
     </doc>
     <field name="title">
         <doc>
-             Title for the plot.
+            Title for the plot.
         </doc>
     </field>
 </definition>

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -403,12 +403,13 @@ def test_yml2xml_comment_parsing():
 
     def recursive_compare(ref_root, test_root):
         assert ref_root.attrib.items() == test_root.attrib.items(), (
-            "Got different xml element" "Atribute."
+            "Got different xml element" "Attribute."
         )
         if ref_root.text and test_root.text:
+            print(ref_root.text, test_root.text)
             assert (
                 ref_root.text.strip() == test_root.text.strip()
-            ), "Got differen element text."
+            ), "Got different element text."
         if len(ref_root) > 0 and len(test_root) > 0:
             for x, y in zip(ref_root, test_root):
                 recursive_compare(x, y)


### PR DESCRIPTION
When converting nyaml files to nxdl.xml files, the docs were written as 
```xml
<group name="level" type="NXelectron_level" recommended="true">
    <doc>
         Electronic core or valence level that was used for the calibration. <-- this is 5 whitespaces indented
    </doc>
</group>
```
The docs were the only element that was indented by 5 whitespaces. 

This PR fixes this problem and consistenly writes 4 whitespaces. This change is also reflected in the tests.