### PR TITLE
handle attributes with datatypes other than NX_CHAR

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message:
   If you use this software, please cite it using the
   metadata from this file.
 type: software
-version: 0.1.2
+version: 0.2.0
 authors:
   - given-names: Andrea
     family-names: Albino

--- a/src/nyaml/nxdl2nyaml.py
+++ b/src/nyaml/nxdl2nyaml.py
@@ -856,7 +856,6 @@ class Nxdl2yaml:
 
         indent = depth * DEPTH_SIZE
         escapesymbol = r"\@"
-        file_out.write(f"{indent}{escapesymbol}{name}:\n")
 
         tmp_dict = {}
         exists_dict = {}
@@ -875,6 +874,14 @@ class Nxdl2yaml:
                 tmp_dict["unit"] = val
             else:
                 tmp_dict[key] = val
+
+        if data_type := tmp_dict.get("type"):
+            name_txt = f"{indent}{escapesymbol}{name}({data_type}):\n"
+            del tmp_dict["type"]
+        else:
+            name_txt = f"{indent}{escapesymbol}{name}:\n"
+
+        file_out.write(name_txt)
 
         has_min_max = False
         has_opt_reco_requ = False

--- a/src/nyaml/nxdl2nyaml.py
+++ b/src/nyaml/nxdl2nyaml.py
@@ -875,8 +875,10 @@ class Nxdl2yaml:
             else:
                 tmp_dict[key] = val
 
-        if data_type := tmp_dict.get("type"):
-            name_txt = f"{indent}{escapesymbol}{name}({data_type}):\n"
+        datatype = tmp_dict.get("type")
+
+        if datatype:
+            name_txt = f"{indent}{escapesymbol}{name}({datatype}):\n"
             del tmp_dict["type"]
         else:
             name_txt = f"{indent}{escapesymbol}{name}:\n"

--- a/tests/data/Ref_NXentry.nxdl.xml
+++ b/tests/data/Ref_NXentry.nxdl.xml
@@ -85,6 +85,18 @@
             Trailing line doc stringy. Trailing lines are removed
         </doc>
     </field>
+    <field name="test_field">
+        <attribute name="vector" type="NX_NUMBER">
+            <doc>
+                Attribute with specific datatype within a field.
+            </doc>
+        </attribute>
+    </field>
+    <attribute name="vector" type="NX_NUMBER">
+        <doc>
+            Attribute with specific datatype within a group.
+        </doc>
+    </attribute>
     <group type="NXuser" />
     <group type="NXsample" />
     <group type="NXinstrument" />

--- a/tests/data/Ref_NXentry.yaml
+++ b/tests/data/Ref_NXentry.yaml
@@ -47,6 +47,13 @@ NXentry(NXobject):
   entry_identifier:
     doc: |
       Trailing line doc stringy. Trailing lines are removed
+  test_field:
+    \@vector(NX_NUMBER):
+      doc: |
+        Attribute with specific datatype within a field.
+  \@vector(NX_NUMBER):
+    doc: |
+      Attribute with specific datatype within a group.
   (NXuser):
   (NXsample):
   (NXinstrument):
@@ -57,7 +64,7 @@ NXentry(NXobject):
   (NXsubentry):
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 6e5f16c6d106f3b59aa4df6a9f254e1ba2041ed235e1f4377d7788adcb8f01a9
+# 995e38abead5a1e2ac7291d32653ac80d9d533e66f9ab05f3d416b5877315c14
 # <?xml version="1.0" encoding="UTF-8"?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 # <!--
@@ -145,6 +152,18 @@ NXentry(NXobject):
 #             Trailing line doc stringy. Trailing lines are removed
 #         </doc>
 #     </field>
+#     <field name="test_field">
+#         <attribute name="vector" type="NX_NUMBER">
+#             <doc>
+#                 Attribute with specific datatype within a field.
+#             </doc>
+#         </attribute>
+#     </field>
+#     <attribute name="vector" type="NX_NUMBER">
+#         <doc>
+#             Attribute with specific datatype within a group.
+#         </doc>
+#     </attribute>
 #     <group type="NXuser" />
 #     <group type="NXsample" />
 #     <group type="NXinstrument" />

--- a/tests/data/yaml2nxdl/NXattributes.yaml
+++ b/tests/data/yaml2nxdl/NXattributes.yaml
@@ -34,3 +34,13 @@ NXellipsometry_base_draft(my_test_extends):
         Calibration is performed on a reference surface (usually silicon wafer with well
         defined oxide layer) at a number of angles, then in a straight through mode
         (transmission in air).
+      dimensions:
+        rank: 3
+        dim: [[3, N_calibration_angles+1], [2, N_variables], [1, N_calibration_wavelength]]
+        dim_parameters:
+          required: ['true', 'true', 'true']
+    test_field:
+      \@vector(NX_NUMBER):
+        doc: Attribute with specific datatype within a field.
+    \@vector(NX_NUMBER):
+      doc: Attribute with specific datatype within a group.

--- a/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2010-2020 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2010-2020 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2025-2025 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -78,6 +78,23 @@
                 defined oxide layer) at a number of angles, then in a straight through mode
                 (transmission in air).
             </doc>
+            <dimensions rank="3">
+                <dim index="3" value="N_calibration_angles+1"/>
+                <dim index="2" value="N_variables"/>
+                <dim index="1" value="N_calibration_wavelength"/>
+            </dimensions>
         </field>
+        <field name="test_field">
+            <attribute name="vector" type="NX_NUMBER">
+                <doc>
+                    Attribute with specific datatype within a field.
+                </doc>
+            </attribute>
+        </field>
+        <attribute name="vector" type="NX_NUMBER">
+            <doc>
+                Attribute with specific datatype within a group.
+            </doc>
+        </attribute>
     </group>
 </definition>


### PR DESCRIPTION
This solves the following problem. Suppose I have in my nyaml file an attribute with a datatype other than `NX_CHAR`:
```yaml
\@vector(NX_NUMBER):
```
That gets correctly converted to
```xml
<attribute name="vector" type="NX_NUMBER"/>
```
However, on the backwards conversion, I got
```yaml
\@vector:
  type: NX_NUMBER:
```

This PR enforces that during the backwards conversion, we again write `\@vector(NX_NUMBER):`, similar to how it is done for fields.