### PR TITLE
nxdl2nyaml: handle enumerations together with comments

### DIFF
--- a/src/nyaml/nxdl2nyaml.py
+++ b/src/nyaml/nxdl2nyaml.py
@@ -829,21 +829,28 @@ class Nxdl2yaml:
                 elif child_tag == CMNT_TAG and self.include_comment:
                     self.handle_comment(depth + 1, child, file_out)
         else:
+            enum_with_comment = False
             enum_list = []
             for child in node_children:
                 child_tag = remove_namespace_from_tag(child.tag)
                 if child_tag == "item":
                     enum_list.append(child.attrib["value"])
                 elif child_tag == CMNT_TAG and self.include_comment:
+                    file_out.write("\n")
                     self.handle_comment(depth + 1, child, file_out)
+                    # If there is a comment, we need to use the long notation with "items:"
+                    enum_with_comment = True
 
             if open_enum:
-                file_out.write(f"\n{indent + DEPTH_SIZE}open_enum: True")
+                file_out.write(f"{indent + DEPTH_SIZE}open_enum: True\n")
+
+            if open_enum or enum_with_comment:
                 file_out.write(
-                    f"\n{indent + DEPTH_SIZE}{'items'}: [{', '.join(enum_list)}]\n"
+                    f"{indent + DEPTH_SIZE}{'items'}: [{', '.join(enum_list)}]\n"
                 )
 
             else:
+                # Short notation as list if there is no comment or open enum
                 file_out.write(f" [{', '.join(enum_list)}]\n")
 
     def handle_attributes(self, depth, node, file_out):

--- a/tests/data/enumerations_nxdl2yaml.nxdl.xml
+++ b/tests/data/enumerations_nxdl2yaml.nxdl.xml
@@ -25,24 +25,16 @@
     <doc>
         This is a test for enumerations.
     </doc>
+    <!-- comment0 -->
     <group type="NXentry">
         <field name="closed_enum_no_docs_list">
             <doc>
                 This is a closed enumeration without any docstrings for the individual items.
                 The items are stored in a flat list.
             </doc>
+            <!-- comment0 -->
             <enumeration>
-                <item value="value0"/>
-                <item value="value1"/>
-                <item value="value2"/>
-            </enumeration>
-        </field>
-        <field name="closed_enum_no_docs_dict">
-            <doc>
-                This is a closed enumeration without any docstrings for the individual items.
-                The items are stored in a dict with the items keyword.
-            </doc>
-            <enumeration>
+                <!-- comment1 -->
                 <item value="value0"/>
                 <item value="value1"/>
                 <item value="value2"/>
@@ -74,7 +66,9 @@
                 This is a closed enumeration, with each item having a docstring.
             </doc>
             <enumeration>
+                <!-- comment2 -->
                 <item value="value0">
+                    <!-- comment3 -->
                     <doc>
                         Doc for value0
                     </doc>
@@ -96,6 +90,7 @@
                 This is an open enumeration without any docstrings for the individual items.
             </doc>
             <enumeration open="True">
+                <!-- comment4 -->
                 <item value="value0"/>
                 <item value="value1"/>
                 <item value="value2"/>
@@ -106,7 +101,9 @@
                 This is a closed enumeration, with each item havin a docstring.
             </doc>
             <enumeration open="True">
+                <!-- comment5 -->
                 <item value="value0">
+                    <!-- comment6 --> 
                     <doc>
                         Doc for value0
                     </doc>

--- a/tests/data/ref_enumerations.yaml
+++ b/tests/data/ref_enumerations.yaml
@@ -3,17 +3,19 @@ doc: |
   This is a test for enumerations.
 type: group
 NXenums(NXobject):
+  
+  # comment0
   (NXentry):
     closed_enum_no_docs_list:
       doc: |
         This is a closed enumeration without any docstrings for the individual items.
         The items are stored in a flat list.
-      enumeration: [value0, value1, value2]
-    closed_enum_no_docs_dict:
-      doc: |
-        This is a closed enumeration without any docstrings for the individual items.
-        The items are stored in a dict with the items keyword.
-      enumeration: [value0, value1, value2]
+      
+      # comment0
+      enumeration:
+        
+        # comment1
+        items: [value0, value1, value2]
     closed_enum_with_numbers(NX_NUMBER):
       doc: |
         This is a closed enumeration without NX_NUMBER items.
@@ -27,7 +29,11 @@ NXenums(NXobject):
       doc: |
         This is a closed enumeration, with each item having a docstring.
       enumeration:
+        
+        # comment2
         value0:
+          
+          # comment3
           doc: |
             Doc for value0
         value1:
@@ -40,6 +46,8 @@ NXenums(NXobject):
       doc: |
         This is an open enumeration without any docstrings for the individual items.
       enumeration:
+        
+        # comment4
         open_enum: True
         items: [value0, value1, value2]
     open_enum_with_docs:
@@ -47,7 +55,11 @@ NXenums(NXobject):
         This is a closed enumeration, with each item havin a docstring.
       enumeration:
         open_enum: True
+        
+        # comment5
         value0:
+          
+          # comment6
           doc: |
             Doc for value0
         value1:
@@ -72,7 +84,7 @@ NXenums(NXobject):
             Doc for [0, 1, 0]
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# e0fd827ccc11befaf44db6666f52069d0b4c0a50b4ce2d8b11089794683c0697
+# 5d14528066ca9b9398a9955c6a4d67be48baa5b5e34d44e99911f17e185818b9
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -100,24 +112,16 @@ NXenums(NXobject):
 #     <doc>
 #         This is a test for enumerations.
 #     </doc>
+#     <!-- comment0 -->
 #     <group type="NXentry">
 #         <field name="closed_enum_no_docs_list">
 #             <doc>
 #                 This is a closed enumeration without any docstrings for the individual items.
 #                 The items are stored in a flat list.
 #             </doc>
+#             <!-- comment0 -->
 #             <enumeration>
-#                 <item value="value0"/>
-#                 <item value="value1"/>
-#                 <item value="value2"/>
-#             </enumeration>
-#         </field>
-#         <field name="closed_enum_no_docs_dict">
-#             <doc>
-#                 This is a closed enumeration without any docstrings for the individual items.
-#                 The items are stored in a dict with the items keyword.
-#             </doc>
-#             <enumeration>
+#                 <!-- comment1 -->
 #                 <item value="value0"/>
 #                 <item value="value1"/>
 #                 <item value="value2"/>
@@ -149,7 +153,9 @@ NXenums(NXobject):
 #                 This is a closed enumeration, with each item having a docstring.
 #             </doc>
 #             <enumeration>
+#                 <!-- comment2 -->
 #                 <item value="value0">
+#                     <!-- comment3 -->
 #                     <doc>
 #                         Doc for value0
 #                     </doc>
@@ -171,6 +177,7 @@ NXenums(NXobject):
 #                 This is an open enumeration without any docstrings for the individual items.
 #             </doc>
 #             <enumeration open="True">
+#                 <!-- comment4 -->
 #                 <item value="value0"/>
 #                 <item value="value1"/>
 #                 <item value="value2"/>
@@ -181,7 +188,9 @@ NXenums(NXobject):
 #                 This is a closed enumeration, with each item havin a docstring.
 #             </doc>
 #             <enumeration open="True">
+#                 <!-- comment5 -->
 #                 <item value="value0">
+#                     <!-- comment6 --> 
 #                     <doc>
 #                         Doc for value0
 #                     </doc>


### PR DESCRIPTION
Handles the unfortunate case 
```xml
<enumeration>
    <!-- comment1 -->
    <item value="value0"/>
    <item value="value1"/>
    <item value="value2"/>
</enumeration>
```
for which it is impossible to use the short notation
```yaml
enumeration: [value0, value1, value2]
```
because we cannot store the comments between `enumeration` and the list.

Thus, we go with the long notation
```yaml
enumeration:
  # comment1
  items: [value0, value1, value2]
```
which we also use for open enumerations.