### PR TITLE
Resolve dimension ambiguity.

### DIFF
--- a/.cspell/custom-dictionary.txt
+++ b/.cspell/custom-dictionary.txt
@@ -57,3 +57,4 @@ somedocstring
 someint
 somevalue
 val
+sourceline

--- a/src/nyaml/nxdl2nyaml.py
+++ b/src/nyaml/nxdl2nyaml.py
@@ -765,6 +765,24 @@ class Nxdl2yaml:
                             "Found incorrect dim child that has no index attribute !"
                         )
 
+        dim_count = sum(1 for val in yml_dim_dct.values() if isinstance(val, dict))
+        rank_value = yml_dim_dct.get(r"\rank")
+        if rank_value is not None and dim_count > 0:
+            try:
+                rank_as_int = int(rank_value)
+            except (TypeError, ValueError):
+                rank_as_int = None  # Symbolic rank is allowed and cannot be validated.
+            if rank_as_int is not None and rank_as_int != dim_count:
+                line_info = (
+                    f"Line {node.sourceline}: "
+                    if getattr(node, "sourceline", None) is not None
+                    else ""
+                )
+                raise ValueError(
+                    f"{line_info}rank '{rank_as_int}' does not match the "
+                    f"number of dim entries ({dim_count})."
+                )
+
         # perform I/O based on the cases analyzed
         yml_dim_dct_keys = list(yml_dim_dct)
         indent = depth * DEPTH_SIZE

--- a/src/nyaml/nyaml2nxdl.py
+++ b/src/nyaml/nyaml2nxdl.py
@@ -439,6 +439,22 @@ def xml_handle_dimensions(
     line_number = f"__line__{keyword}"
     line_loc = dct[line_number]
     dims: ET.Element | None = None
+
+    def validate_rank_dim_count(dim_count: int, rank_value: Any) -> None:
+        """Validate rank against explicit dimension count when rank is provided."""
+        try:
+            rank_value = int(rank_value)
+        except (ValueError, TypeError):
+            return  # Descriptive rank
+        if rank_value is None:
+            return
+
+        if int(rank_value) != int(dim_count):
+            raise ValueError(
+                f"Line {line_loc}: rank '{rank_value}' does not match the "
+                f"number of dim entries ({dim_count})."
+            )
+
     if isinstance(value, dict):
         # Normalize escape-prefixed keywords inside a dimensions block to their bare
         # internal names (which the rest of this function uses).
@@ -471,6 +487,7 @@ def xml_handle_dimensions(
             dims = ET.SubElement(obj, "dimensions")
             if "rank" in value:
                 dims.set("rank", f"{value['rank']}")
+                validate_rank_dim_count(n_idx_dicts, value.get("rank", None))
             if "doc" in value:
                 docs = ET.SubElement(dims, "doc")
                 docs.text = f"\n{value['doc']}"
@@ -498,6 +515,7 @@ def xml_handle_dimensions(
             if re.match("^\\([A-Za-z0-9_, ]+\\)$", value["dim"]) is not None:
                 # common for cases shorthand_terse and shorthand_explicit_rank_new
                 dims = ET.SubElement(obj, "dimensions")
+                dim_count = 0
                 # rank = 0
                 if "doc" in value:
                     docs = ET.SubElement(dims, "doc")
@@ -506,23 +524,33 @@ def xml_handle_dimensions(
                     value["dim"][1:-1].replace(" ", "").split(",")
                 ):
                     if val != "":
+                        dim_count += 1
                         dim = ET.SubElement(dims, "dim")
                         dim.set("index", f"{idx + 1}")
                         dim.set("value", f"{val}")
                     # rank += 1
+                validate_rank_dim_count(
+                    dim_count=dim_count, rank_value=value.get("rank", None)
+                )
                 if "rank" in value:  # shorthand_explicit_rank_new
                     dims.set("rank", f"{value['rank']}")
+                    validate_rank_dim_count(dim_count, value["rank"])
                 # else:  # shorthand_terse, automatic setting of rank switched off
                 #     dims.set("rank", f"{rank}")
         elif "dim" in value and isinstance(value["dim"], list) and "rank" in value:
+            validate_rank_dim_count(
+                dim_count=len(value["dim"]), rank_value=value.get("rank", None)
+            )
             # shorthand_explicit_rank_old
             dims = ET.SubElement(obj, "dimensions")
             dims.set("rank", f"{value['rank']}")
+            dim_count = 0
             if "doc" in value:
                 docs = ET.SubElement(dims, "doc")
                 docs.text = f"\n{value['doc']}"
             for entry in value["dim"]:
                 if len(entry) == 2 and all(val != "" for val in entry):
+                    dim_count += 1
                     dim = ET.SubElement(dims, "dim")
                     dim.set("index", f"{entry[0]}")
                     dim.set("value", f"{entry[1]}")

--- a/src/nyaml/nyaml2nxdl.py
+++ b/src/nyaml/nyaml2nxdl.py
@@ -445,7 +445,7 @@ def xml_handle_dimensions(
         try:
             rank_value = int(rank_value)
         except (ValueError, TypeError):
-            return  # Descriptive rank
+            return  # Descriptive rank coming from symbolic name
         if rank_value is None:
             return
 

--- a/tests/data/nxdl2yaml/NXdimensionsType.nxdl.xml
+++ b/tests/data/nxdl2yaml/NXdimensionsType.nxdl.xml
@@ -89,7 +89,7 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
                 the XML content substantiates that either using
                 rank_only suffices or that full_syntax is required.
             </doc>
-            <dimensions rank="2">
+            <dimensions rank="3">
                 <dim index="1" value="1"/>
                 <dim index="2" value="symbol_a"/>
                 <dim index="3" value="symbol_b"/>
@@ -99,7 +99,7 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
             <doc>
                 The same as shorthand_explicit_rank_new, but with docs for the dimensions tag.
             </doc>
-            <dimensions rank="2">
+            <dimensions rank="3">
                 <doc>
                     Some docs.
                 </doc>

--- a/tests/data/nxdl2yaml/Ref_NXdimensionsType.yaml
+++ b/tests/data/nxdl2yaml/Ref_NXdimensionsType.yaml
@@ -14,7 +14,7 @@
 \type: group
 NXdimensions(NXobject):
   (NXentry):
-
+    
     # provided a proper escape sign is used also an even more compact way could be possible
     minimal(NX_NUMBER):
       \doc: |
@@ -45,22 +45,22 @@ NXdimensions(NXobject):
         Shorthand where the rank can be set explicitly. For testing purposes
         the rank is here intentionally set to a value that is different to the number
         of entries in dim.
-
+        
         Authors and designers of NeXus classes should preferentially use
         the shorthand notation unless the full_syntax is required as
         using rank_only is insufficient.
-
+        
         This is the default to which nxdl2yaml converts unless
         the XML content substantiates that either using
         rank_only suffices or that full_syntax is required.
       \dimensions:
-        \rank: 2
+        \rank: 3
         \dim: (1, symbol_a, symbol_b)
     shorthand_explicit_rank_new_with_docs(NX_NUMBER):
       \doc: |
         The same as shorthand_explicit_rank_new, but with docs for the dimensions tag.
       \dimensions:
-        \rank: 2
+        \rank: 3
         \doc: |
           Some docs.
         \dim: (1, symbol_a, symbol_b)
@@ -101,7 +101,7 @@ NXdimensions(NXobject):
           ref: m
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# fbaadcf9c28d77f8d3923789c5b8c4901e15c2ea52f61620fc7bc9200e122e08
+# 170126736195ec23d0f8dc7f63f9a7b19fe201943ef961a044b9946d753829cd
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -184,16 +184,16 @@ NXdimensions(NXobject):
 #                 Shorthand where the rank can be set explicitly. For testing purposes
 #                 the rank is here intentionally set to a value that is different to the number
 #                 of entries in dim.
-#
+#                 
 #                 Authors and designers of NeXus classes should preferentially use
 #                 the shorthand notation unless the full_syntax is required as
 #                 using rank_only is insufficient.
-#
+#                 
 #                 This is the default to which nxdl2yaml converts unless
 #                 the XML content substantiates that either using
 #                 rank_only suffices or that full_syntax is required.
 #             </doc>
-#             <dimensions rank="2">
+#             <dimensions rank="3">
 #                 <dim index="1" value="1"/>
 #                 <dim index="2" value="symbol_a"/>
 #                 <dim index="3" value="symbol_b"/>
@@ -203,7 +203,7 @@ NXdimensions(NXobject):
 #             <doc>
 #                 The same as shorthand_explicit_rank_new, but with docs for the dimensions tag.
 #             </doc>
-#             <dimensions rank="2">
+#             <dimensions rank="3">
 #                 <doc>
 #                     Some docs.
 #                 </doc>

--- a/tests/data/yaml2nxdl/NXdimensionsType.yaml
+++ b/tests/data/yaml2nxdl/NXdimensionsType.yaml
@@ -50,7 +50,7 @@ NXdimensions(NXobject):
         the XML content substantiates that either using
         rank_only suffices or that full_syntax is required.
       \dimensions:
-        \rank: 2
+        \rank: 3
         \dim: (1, symbol_a, symbol_b)
     shorthand_explicit_rank_new_with_docs(NX_NUMBER):
       \doc: |
@@ -58,7 +58,7 @@ NXdimensions(NXobject):
       \dimensions:
         \doc: |
           Some docs.
-        \rank: 2
+        \rank: 3
         \dim: (1, symbol_a, symbol_b)
     shorthand_explicit_rank_old(NX_NUMBER):
       \doc: |

--- a/tests/data/yaml2nxdl/NXdimensionsType.yaml
+++ b/tests/data/yaml2nxdl/NXdimensionsType.yaml
@@ -94,8 +94,6 @@ NXdimensions(NXobject):
         \rank: symbol_a
     dimensions_without_dim(NX_NUMBER):
       \doc: |
-        This is an example of a dimensions definition that does not specify the rank.
-        This is not recommended as it can lead to ambiguity and is not supported by
-        the current version of nyaml2nxdl.
+        This is an example of a dimensions definition that does not specify the dim.
       \dimensions:
         \rank: 5

--- a/tests/data/yaml2nxdl/NXdimensionsType.yaml
+++ b/tests/data/yaml2nxdl/NXdimensionsType.yaml
@@ -92,3 +92,10 @@ NXdimensions(NXobject):
         Shorthand for cases that specify only the rank.
       \dimensions:
         \rank: symbol_a
+    dimensions_without_dim(NX_NUMBER):
+      \doc: |
+        This is an example of a dimensions definition that does not specify the rank.
+        This is not recommended as it can lead to ambiguity and is not supported by
+        the current version of nyaml2nxdl.
+      \dimensions:
+        \rank: 5

--- a/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
@@ -138,5 +138,13 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
             </doc>
             <dimensions rank="symbol_a"/>
         </field>
+        <field name="dimensions_without_dim" type="NX_NUMBER">
+            <doc>
+                This is an example of a dimensions definition that does not specify the rank.
+                This is not recommended as it can lead to ambiguity and is not supported by
+                the current version of nyaml2nxdl.
+            </doc>
+            <dimensions rank="5"/>
+        </field>
     </group>
 </definition>

--- a/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
@@ -140,9 +140,7 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
         </field>
         <field name="dimensions_without_dim" type="NX_NUMBER">
             <doc>
-                This is an example of a dimensions definition that does not specify the rank.
-                This is not recommended as it can lead to ambiguity and is not supported by
-                the current version of nyaml2nxdl.
+                This is an example of a dimensions definition that does not specify the dim.
             </doc>
             <dimensions rank="5"/>
         </field>

--- a/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXdimensionsType.nxdl.xml
@@ -89,7 +89,7 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
                 the XML content substantiates that either using
                 rank_only suffices or that full_syntax is required.
             </doc>
-            <dimensions rank="2">
+            <dimensions rank="3">
                 <dim index="1" value="1"/>
                 <dim index="2" value="symbol_a"/>
                 <dim index="3" value="symbol_b"/>
@@ -99,7 +99,7 @@ base_classes/NXsensor, use of index, value and index, ref pairs respectively-->
             <doc>
                 The same as shorthand_explicit_rank_new, but with docs for the dimensions tag.
             </doc>
-            <dimensions rank="2">
+            <dimensions rank="3">
                 <doc>
                     Some docs.
                 </doc>

--- a/tests/test_nxdl2nyaml.py
+++ b/tests/test_nxdl2nyaml.py
@@ -93,6 +93,64 @@ def test_dimension(test_input):
     os.remove(test_yml_output_file)
 
 
+@pytest.mark.parametrize(
+    "rank_value,dim_entries,expected_error",
+    [
+        pytest.param(
+            "2",
+            [
+                '<dim index="1" value="1"/>',
+                '<dim index="2" value="symbol_a"/>',
+                '<dim index="3" value="symbol_b"/>',
+            ],
+            "rank '2' does not match the number of dim entries (3).",
+            id="rank2_vs_3_dims",
+        ),
+        pytest.param(
+            "1",
+            [
+                '<dim index="1" value="symbol_a"/>',
+                '<dim index="2" value="symbol_b"/>',
+            ],
+            "rank '1' does not match the number of dim entries (2).",
+            id="rank1_vs_2_dims",
+        ),
+    ],
+)
+def test_dimensions_rank_dim_mismatch_raises_error(
+    tmp_path, rank_value, dim_entries, expected_error
+):
+    """An explicit numeric rank in NXDL dimensions must match the number of dim entries."""
+    dims_xml = "\n".join(f"        {entry}" for entry in dim_entries)
+    nxdl_text = (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        '<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        'category="application" type="group" name="NXtest" '
+        'extends="NXobject" '
+        'xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">\n'
+        '  <group type="NXentry">\n'
+        '    <field name="some_field" type="NX_NUMBER">\n'
+        f'      <dimensions rank="{rank_value}">\n'
+        f"{dims_xml}\n"
+        "      </dimensions>\n"
+        "    </field>\n"
+        "  </group>\n"
+        "</definition>\n"
+    )
+    input_file = tmp_path / "rank_dim_mismatch.nxdl.xml"
+    parsed_yaml_file = tmp_path / "rank_dim_mismatch_parsed.yaml"
+    input_file.write_text(nxdl_text, encoding="utf-8")
+
+    result = CliRunner().invoke(nyaml2nxdl.launch_tool, [str(input_file)])
+    assert result.exit_code != 0
+    message = str(result.output) + str(result.exception)
+    assert expected_error in message
+
+    if parsed_yaml_file.exists():
+        os.remove(parsed_yaml_file)
+
+
 def test_nxdl2yaml_doc_format_and_nxdl_part_as_comment():
     """
     This test for two reasons:

--- a/tests/test_nyaml2nxdl.py
+++ b/tests/test_nyaml2nxdl.py
@@ -28,7 +28,11 @@ import lxml.etree as ET
 import pytest
 import yaml
 from click.testing import CliRunner
-from helpers import check_and_replace_latest_copyright, compare_matches
+from helpers import (
+    check_and_replace_latest_copyright,
+    compare_log_and_reference,
+    compare_matches,
+)
 
 from nyaml import cli as nyaml2nxdl
 from nyaml.helper import (
@@ -548,6 +552,57 @@ def test_forward_conversion(test_input):
     assert log == ref
 
     os.remove(test_xml_output_file)
+
+
+@pytest.mark.parametrize(
+    "dimension_contents,error_message",
+    [
+        pytest.param(
+            (
+                "\\category: application\n"
+                "\\doc: Rank mismatch test\n"
+                "NXtest(NXobject):\n"
+                "  some_field(NX_NUMBER):\n"
+                "    \\dimensions:\n"
+                "      \\rank: 2\n"
+                "      \\dim: (1, symbol_a, symbol_b)\n"
+            ),
+            "rank '2' does not match the number of dim entries (3).",
+            id="shorthand_tuple_rank2_vs_3dims",
+        ),
+        pytest.param(
+            (
+                "\\category: application\n"
+                "\\doc: Rank mismatch test\n"
+                "NXtest(NXobject):\n"
+                "  some_field(NX_NUMBER):\n"
+                "    \\dimensions:\n"
+                "      \\rank: 2\n"
+                "      \\dim: [[1, symbol_a]]\n"
+            ),
+            "rank '2' does not match the number of dim entries (1).",
+            id="shorthand_old_list_rank2_vs_1dim",
+        ),
+    ],
+)
+def test_dimensions_rank_dim_mismatch_raises_error(
+    tmp_path, dimension_contents, error_message
+):
+    """An explicit numeric rank must match the number of explicit dim entries."""
+
+    yaml_text = dimension_contents
+    test_file = tmp_path / "rank_mismatch.yaml"
+    out_file = tmp_path / "rank_mismatch.nxdl.xml"
+    test_file.write_text(yaml_text, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        nyaml2nxdl.launch_tool,
+        [str(test_file), "--output-file", str(out_file)],
+    )
+
+    assert result.exit_code != 0
+    message = str(result.output) + str(result.exception)
+    assert error_message in message
 
 
 @pytest.mark.parametrize("keyword", sorted(RESERVED_KEYWORDS))


### PR DESCRIPTION
closes #94 

This PR mainly raise an error, if `nyaml` converter sees inconsistency between the Rank and number of total dim element in `yaml-->nxdl conversion`.

But, parse the `nxdl-->yaml` without any issue even though with inconsistent rank. This is intended because, there might have some very old files in `nexus_definition` which has inconsistent dimension. For such files, one `nxdl` to `yaml` is converted and any modification in `yaml` take place the inconsistency must be fixed.
