### PR TITLE
allow `\deprecated` as a reserved keyword

### DIFF
--- a/src/nyaml/nxdl2nyaml.py
+++ b/src/nyaml/nxdl2nyaml.py
@@ -644,6 +644,8 @@ class Nxdl2yaml:
                 if r"\exists" not in tmp_dict:
                     tmp_dict[r"\exists"] = []
                 self.handle_exists(exists_dict, key, val)
+            elif key == "deprecated":
+                tmp_dict[r"\deprecated"] = str(val)
             elif key == "units":
                 tmp_dict[r"\unit"] = str(val)
             else:
@@ -944,6 +946,8 @@ class Nxdl2yaml:
                 self.handle_exists(exists_dict, key, val)
             elif key == "units":
                 tmp_dict[r"\unit"] = val
+            elif key == "deprecated":
+                tmp_dict[r"\deprecated"] = str(val)
             else:
                 # Escape reserved keywords so they are not misinterpreted on round-trip
                 escaped_key = f"\\{key}" if key in RESERVED_KEYWORDS else key

--- a/src/nyaml/nyaml2nxdl.py
+++ b/src/nyaml/nyaml2nxdl.py
@@ -818,10 +818,18 @@ def xml_handle_attributes(
                 r"\exists",
                 r"\nameType",
                 r"\type",
+                r"\deprecated",
                 *YAML_ATTRIBUTES_ATTRIBUTES,
             ] and not isinstance(attr_val, dict):
                 if attr == r"\unit":
                     sub_element.set("units", str(attr_val))
+                    rm_key_list.append(attr)
+                    rm_key_list.append(line_number)
+                    xml_handle_comment(obj, line_number, line_loc, sub_element)
+                if attr == r"\deprecated" and attr_val:
+                    sub_element.set(
+                        "deprecated", check_for_mapping_char_other(attr_val)
+                    )
                     rm_key_list.append(attr)
                     rm_key_list.append(line_number)
                     xml_handle_comment(obj, line_number, line_loc, sub_element)
@@ -855,7 +863,7 @@ def xml_handle_attributes(
             del value[key]
         # Check cor skipped attribute
         check_for_skipped_attributes(
-            "Attribute", value, YAML_ATTRIBUTES_ATTRIBUTES, verbose
+            "attribute", value, YAML_ATTRIBUTES_ATTRIBUTES, verbose
         )
     if value:
         recursive_build(sub_element, value, verbose)

--- a/tests/data/nxdl2yaml/NXattributes.nxdl.xml
+++ b/tests/data/nxdl2yaml/NXattributes.nxdl.xml
@@ -49,7 +49,7 @@
                 documentation no. 3
             </doc>
         </field>
-        <field name="experiment_description" optional="false"/>
+        <field name="experiment_description" optional="false" deprecated="true"/>
         <field name="start_time" type="NX_DATE_TIME" optional="false" units="NX_TIME"/>
         <field name="program_name">
             <doc>
@@ -70,7 +70,7 @@
             <doc>
                 documentation no. 7
             </doc>
-            <attribute name="version"/>
+            <attribute name="version" deprecated="true"/>
         </field>
         <field name="calibration_data" type="NX_NUMBER" units="NX_UNITLESS">
             <doc>

--- a/tests/data/nxdl2yaml/Ref_NXattributes.yaml
+++ b/tests/data/nxdl2yaml/Ref_NXattributes.yaml
@@ -20,6 +20,7 @@ NXellipsometry_base_draft(my_test_extends):
         documentation no. 3
     experiment_description:
       \exists: optional
+      \deprecated: true
     start_time(NX_DATE_TIME):
       \exists: optional
       \unit: NX_TIME
@@ -39,6 +40,7 @@ NXellipsometry_base_draft(my_test_extends):
       \doc: |
         documentation no. 7
       \@version:
+        \deprecated: true
     calibration_data(NX_NUMBER):
       \unit: NX_UNITLESS
       \doc: |
@@ -47,7 +49,7 @@ NXellipsometry_base_draft(my_test_extends):
         (transmission in air).
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# abafd962b1e78462ba064863826bfe6a7cbc98c73c91ffefd9c923faee03cf9e
+# 9afa2ceb0d71c7e1cb16d3098abcb36bb25e118cad2373e9d3195a54b9a534cf
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -99,7 +101,7 @@ NXellipsometry_base_draft(my_test_extends):
 #                 documentation no. 3
 #             </doc>
 #         </field>
-#         <field name="experiment_description" optional="false"/>
+#         <field name="experiment_description" optional="false" deprecated="true"/>
 #         <field name="start_time" type="NX_DATE_TIME" optional="false" units="NX_TIME"/>
 #         <field name="program_name">
 #             <doc>
@@ -120,7 +122,7 @@ NXellipsometry_base_draft(my_test_extends):
 #             <doc>
 #                 documentation no. 7
 #             </doc>
-#             <attribute name="version"/>
+#             <attribute name="version" deprecated="true"/>
 #         </field>
 #         <field name="calibration_data" type="NX_NUMBER" units="NX_UNITLESS">
 #             <doc>

--- a/tests/data/nxdl2yaml/allowed_nameType.nxdl.xml
+++ b/tests/data/nxdl2yaml/allowed_nameType.nxdl.xml
@@ -25,7 +25,7 @@
     <doc>
         NXnametype test
     </doc>
-    <group name="lower_case_group_no_nametype" type="NXobject">
+    <group name="lower_case_group_no_nametype" type="NXobject" deprecated="true">
         <doc>
             An all lower case group with no nameType.
         </doc>

--- a/tests/data/nxdl2yaml/ref_allowed_nameType.yaml
+++ b/tests/data/nxdl2yaml/ref_allowed_nameType.yaml
@@ -4,6 +4,7 @@
 \type: group
 NXallowed_name_type(NXobject):
   lower_case_group_no_nametype(NXobject):
+    \deprecated: true
     \doc: |
       An all lower case group with no nameType.
     lower_case_field_no_nametype:
@@ -143,7 +144,7 @@ NXallowed_name_type(NXobject):
             variadic parts.
 
 # ++++++++++++++++++++++++++++++++++ SHA HASH ++++++++++++++++++++++++++++++++++
-# 29a66a4a61f5a6bbfdc6cfbdeb05e2972035d588dbbb8b22845fee404fc7290c
+# 8f54bcc556a8b3effa77654cee1c81f60ae156d915412c1eb87a089fcfd9ccb3
 # <?xml version='1.0' encoding='UTF-8'?>
 # <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 # <!--
@@ -171,7 +172,7 @@ NXallowed_name_type(NXobject):
 #     <doc>
 #         NXnametype test
 #     </doc>
-#     <group name="lower_case_group_no_nametype" type="NXobject">
+#     <group name="lower_case_group_no_nametype" type="NXobject" deprecated="true">
 #         <doc>
 #             An all lower case group with no nameType.
 #         </doc>

--- a/tests/data/yaml2nxdl/NXattributes.yaml
+++ b/tests/data/yaml2nxdl/NXattributes.yaml
@@ -13,6 +13,7 @@ NXellipsometry_base_draft(my_test_extends):
       \doc: documentation no. 3
     experiment_description:
       \exists: required
+      \deprecated: true
     start_time(NX_DATE_TIME):
       \exists: required
       \unit: NX_TIME
@@ -28,6 +29,7 @@ NXellipsometry_base_draft(my_test_extends):
       \exists: ['max', 5]
       \doc: documentation no. 7
       \@version:
+        \deprecated: true
     calibration_data(NX_NUMBER):
       \unit: NX_UNITLESS
       \doc: |

--- a/tests/data/yaml2nxdl/NXfit.yaml
+++ b/tests/data/yaml2nxdl/NXfit.yaml
@@ -13,6 +13,7 @@ NXfit(NXprocess):
     \doc: |
       Human-readable label for this fit procedure.
   data(NXdata):
+    \deprecated: true
     \doc: |
       Input data and results of the fit.
     input_dependent(NX_NUMBER):

--- a/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXattributes.nxdl.xml
@@ -49,7 +49,7 @@
                 documentation no. 3
             </doc>
         </field>
-        <field name="experiment_description" optional="false"/>
+        <field name="experiment_description" optional="false" deprecated="true"/>
         <field name="start_time" type="NX_DATE_TIME" optional="false" units="NX_TIME"/>
         <field name="program_name">
             <doc>
@@ -70,7 +70,7 @@
             <doc>
                 documentation no. 7
             </doc>
-            <attribute name="version"/>
+            <attribute name="version" deprecated="true"/>
         </field>
         <field name="calibration_data" type="NX_NUMBER" units="NX_UNITLESS">
             <doc>

--- a/tests/data/yaml2nxdl/Ref_NXfit.nxdl.xml
+++ b/tests/data/yaml2nxdl/Ref_NXfit.nxdl.xml
@@ -41,7 +41,7 @@
             Human-readable label for this fit procedure.
         </doc>
     </field>
-    <group name="data" type="NXdata">
+    <group name="data" type="NXdata" deprecated="true">
         <doc>
             Input data and results of the fit.
         </doc>


### PR DESCRIPTION
This fixes the issue that `\deprecated` was not recognized as a reserved keyword (in both directions). Seen first when testing the main branch on the eixsting NeXus definitions.