### PR TITLE
Include yaml linter for CITATION.cff file.

### DIFF
--- a/.github/workflows/cff-validation.yml
+++ b/.github/workflows/cff-validation.yml
@@ -35,3 +35,6 @@ jobs:
           sed -i '/^funding:/,$d' CITATION.cff 
 
           uv run --with cffconvert cffconvert --validate --format zenodo || exit 1
+      - name: Validate yaml rules in CITATION.cff
+        run: |
+          uv run --with yamllint yamllint -c .yamllint.yml CITATION.cff || exit 1

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,24 @@
+extends: default
+
+ignore: |
+  .git/
+  .venv/
+  .PE*/
+  build/
+  site/
+  nyaml.egg-info/
+  src/nyaml.egg-info/
+  **/*.dist-info/
+
+rules:
+  document-start: disable
+  comments-indentation: disable
+  line-length:
+    max: 160
+    level: warning
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  truthy: disable
+  indentation:
+    spaces: 2
+    indent-sequences: consistent

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,15 +47,15 @@ abstract:
   nyaml is a Python software tool designed for developers and users of the NeXus data exchange format
   (https://www.nexusformat.org/). The tool converts files that follow the NeXus Definition Language
   (NXDL) from XML to [YAML](https://yaml.org/), and vice versa.
-  
+
   NXDL is used to define experiment instruments, setups, or scientific data objects from experiments
   in a schema-based structure. Writing NeXus data schemas via the indentation-based formatting of
   YAML offers a more concise writing and reduces common sources of formatting inconsistencies,
   while still adhering to NeXus standards.
-  
+
   The tool requires users to follow a specific grammar for embedding NeXus data structures to ensure
   compatibility with NXDL (see the full documentation at https://fairmat-nfdi.github.io/nyaml/).
-  
+
   The work is funded by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) - 460197019 (FAIRmat)
   (https://gepris.dfg.de/gepris/projekt/460197019?language=en).
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: 'nyaml: A Python package that converts NeXus application definitions and base classes from the NXDL XML format to the YAML format and vice versa'
-version: 1.0.0
+version: 1.0.1
 message:
   If you use this software, please cite it using the
   metadata from this file.


### PR DESCRIPTION
This PR adds a check if the yaml file follows valid yaml rules and prevents the `yaml` parsing error in Zenodo.